### PR TITLE
[feature] MainActivity 지도 띄우기

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -49,6 +49,7 @@ android {
         jvmTarget = "1.8"
     }
     buildFeatures {
+        viewBinding = true
         buildConfig = true
         compose = true
     }
@@ -74,6 +75,8 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
+    implementation(libs.androidx.constraintlayout)
+    implementation(libs.androidx.ui.viewbinding)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,7 +21,7 @@
             android:name=".MainActivity"
             android:exported="true"
             android:label="@string/app_name"
-            android:theme="@style/Theme.MusicRoad">
+            android:theme="@style/Theme.AppCompat.NoActionBar">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/com/squirtles/musicroad/MainActivity.kt
+++ b/app/src/main/java/com/squirtles/musicroad/MainActivity.kt
@@ -1,47 +1,44 @@
 package com.squirtles.musicroad
 
 import android.os.Bundle
-import androidx.activity.ComponentActivity
+import android.view.View
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.fragment.app.FragmentActivity
+import androidx.fragment.app.FragmentContainerView
+import com.squirtles.musicroad.map.MapFragment
 import com.squirtles.musicroad.ui.theme.MusicRoadTheme
 
-class MainActivity : ComponentActivity() {
+class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
+
         setContent {
             MusicRoadTheme {
-                Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    Greeting(
-                        name = "Android",
-                        modifier = Modifier.padding(innerPadding)
-                    )
-                }
+                MapFragmentContainer()
             }
         }
     }
 }
 
 @Composable
-fun Greeting(name: String, modifier: Modifier = Modifier) {
-    Text(
-        text = "Hello $name!",
-        modifier = modifier
-    )
-}
+fun MapFragmentContainer() {
+    AndroidView(
+        modifier = Modifier.fillMaxSize(),
+        factory = { context ->
+            FragmentContainerView(context).apply {
+                id = View.generateViewId()
 
-@Preview(showBackground = true)
-@Composable
-fun GreetingPreview() {
-    MusicRoadTheme {
-        Greeting("Android")
-    }
+                (context as FragmentActivity).supportFragmentManager.beginTransaction()
+                    .replace(id, MapFragment())
+                    .commitAllowingStateLoss()
+            }
+        }
+    )
 }

--- a/app/src/main/java/com/squirtles/musicroad/map/MapFragment.kt
+++ b/app/src/main/java/com/squirtles/musicroad/map/MapFragment.kt
@@ -1,0 +1,27 @@
+package com.squirtles.musicroad.map
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import com.squirtles.musicroad.databinding.FragmentMapBinding
+
+class MapFragment : Fragment() {
+
+    private var _binding: FragmentMapBinding? = null
+    private val binding get() = _binding!!
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentMapBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/app/src/main/res/layout/fragment_map.xml
+++ b/app/src/main/res/layout/fragment_map.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/fragment_map"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".map.MapFragment">
+
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/container_map"
+        android:name="com.naver.maps.map.MapFragment"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,8 @@ okhttp = "4.12.0"
 retrofit = "2.11.0"
 kotlinxSerializationJson = "1.6.0"
 googleServices = "4.4.2"
+constraintlayout = "2.2.0"
+uiViewbinding = "1.7.5"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -50,6 +52,8 @@ okhttp-logging = { group = "com.squareup.okhttp3", name = "logging-interceptor",
 retrofit-core = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }
 retrofit-kotlin-serialization = { module = "com.squareup.retrofit2:converter-kotlinx-serialization", version.ref = "retrofit" }
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
+androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
+androidx-ui-viewbinding = { group = "androidx.compose.ui", name = "ui-viewbinding", version.ref = "uiViewbinding" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## #️⃣연관된 이슈

> Closes #8 

## 📝작업 내용 및 코드

> 
### MapFragment 생성 및 xml 레이아웃 생성 
### MainActivity : ComponentActivity -> AppCompatActivity로 변경
- ComponentActivity는 supportFragmentManager이 없기 때문 
### MapFragment띄우는 컴포즈 정의
```kotlin
@Composable
fun MapFragmentContainer() {
    AndroidView(
        modifier = Modifier.fillMaxSize(),
        factory = { context ->
            FragmentContainerView(context).apply {
                id = View.generateViewId()

                (context as FragmentActivity).supportFragmentManager.beginTransaction()
                    .replace(id, MapFragment())
                    .commitAllowingStateLoss()
            }
        }
    )
}

...
setContent {
    MusicRoadTheme {
        MapFragmentContainer()
    }
}
```

![image](https://github.com/user-attachments/assets/74668f62-4a67-4bae-bf54-a9aa97111557)


## 💬리뷰 요구사항(선택)

>