### PR TITLE
[feature] 현재 위치에 마커 생성

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -104,6 +104,7 @@ dependencies {
     implementation(libs.play.services.location)
 
     // Coil
+    implementation(libs.coil)
     implementation(libs.coil.compose)
     implementation(libs.coil.network.okhttp)
 }

--- a/app/src/main/java/com/squirtles/musicroad/map/MapScreen.kt
+++ b/app/src/main/java/com/squirtles/musicroad/map/MapScreen.kt
@@ -68,6 +68,7 @@ fun MapScreen(
                     .align(Alignment.BottomCenter)
                     .padding(bottom = 16.dp),
                 onFavoriteClick = onFavoriteClick,
+                onCenterClick = { mapViewModel.createMarker() },
                 onSettingClick = onSettingClick
             )
         }
@@ -78,6 +79,7 @@ fun MapScreen(
 fun BottomNavigation(
     modifier: Modifier = Modifier,
     onFavoriteClick: () -> Unit,
+    onCenterClick: () -> Unit,
     onSettingClick: () -> Unit
 ) {
     Box(
@@ -129,7 +131,7 @@ fun BottomNavigation(
                 .size(82.dp)
                 .clip(CircleShape)
                 .background(color = MaterialTheme.colorScheme.primary)
-                .clickable { /* TODO: 픽 등록 이동 */ },
+                .clickable { onCenterClick() }, // TODO: 픽 등록 이동으로 변경하기
             contentAlignment = Alignment.Center
         ) {
             Icon(
@@ -148,6 +150,7 @@ fun BottomNavigationLightPreview() {
     MusicRoadTheme {
         BottomNavigation(
             onFavoriteClick = {},
+            onCenterClick = {},
             onSettingClick = {}
         )
     }
@@ -159,6 +162,7 @@ fun BottomNavigationDarkPreview() {
     MusicRoadTheme {
         BottomNavigation(
             onFavoriteClick = {},
+            onCenterClick = {},
             onSettingClick = {}
         )
     }

--- a/app/src/main/java/com/squirtles/musicroad/map/MapViewModel.kt
+++ b/app/src/main/java/com/squirtles/musicroad/map/MapViewModel.kt
@@ -1,5 +1,6 @@
 package com.squirtles.musicroad.map
 
+import android.location.Location
 import android.util.Log
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
@@ -7,6 +8,10 @@ import androidx.lifecycle.viewModelScope
 import com.squirtles.domain.usecase.FetchPickInAreaUseCase
 import com.squirtles.domain.usecase.FetchPickUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -16,6 +21,23 @@ class MapViewModel @Inject constructor(
     private val fetchPickUseCase: FetchPickUseCase,
     private val fetchPickInAreaUseCase: FetchPickInAreaUseCase
 ) : ViewModel() {
+    private val _centerButtonClick = MutableSharedFlow<Boolean>()
+    val centerButtonClick = _centerButtonClick.asSharedFlow()
+
+    private val _curLocation = MutableStateFlow<Location?>(null)
+    val curLocation = _curLocation.asStateFlow()
+
+    fun createMarker() {
+        viewModelScope.launch {
+            _centerButtonClick.emit(true)
+        }
+    }
+
+    fun updateCurLocation(location: Location) {
+        viewModelScope.launch {
+            _curLocation.value = location
+        }
+    }
 
     fun fetchPick(pickId: String) {
         viewModelScope.launch {

--- a/app/src/main/java/com/squirtles/musicroad/map/MarkerIconView.kt
+++ b/app/src/main/java/com/squirtles/musicroad/map/MarkerIconView.kt
@@ -40,12 +40,28 @@ class MarkerIconView(
     override fun onDraw(canvas: Canvas) {
         super.onDraw(canvas)
 
-        canvas.drawRect((width - STROKE_WIDTH) / 2f, width / 2f, (width + STROKE_WIDTH) / 2f, height.toFloat(), fillPaint)
+        canvas.drawRect(
+            (width - STROKE_WIDTH) / 2f,
+            width / 2f,
+            (width + STROKE_WIDTH) / 2f,
+            height.toFloat(),
+            fillPaint
+        )
         bitmap?.let {
             bitmapRect.set(0, 0, width, width)
             canvas.drawBitmap(it, null, bitmapRect, null)
-            canvas.drawCircle(width / 2f, width / 2f, (width - STROKE_WIDTH) / 2f, strokePaint) // bitmap 테두리 그리기
-        } ?: canvas.drawCircle(width / 2f, width / 2f, width / 2f, fillPaint) // bitmap이 null이면 이미지 없이 원만 그려지도록
+            canvas.drawCircle(
+                width / 2f,
+                width / 2f,
+                (width - STROKE_WIDTH) / 2f,
+                strokePaint
+            ) // bitmap 테두리 그리기
+        } ?: canvas.drawCircle(
+            width / 2f,
+            width / 2f,
+            width / 2f,
+            fillPaint
+        ) // bitmap이 null이면 이미지 없이 원만 그려지도록
     }
 
     fun setPaintColor(@ColorInt color: Int) {

--- a/app/src/main/java/com/squirtles/musicroad/map/MarkerIconView.kt
+++ b/app/src/main/java/com/squirtles/musicroad/map/MarkerIconView.kt
@@ -1,0 +1,87 @@
+package com.squirtles.musicroad.map
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.graphics.Rect
+import android.util.AttributeSet
+import android.util.Log
+import android.view.View
+import androidx.annotation.ColorInt
+import coil3.SingletonImageLoader
+import coil3.request.ImageRequest
+import coil3.request.allowHardware
+import coil3.request.transformations
+import coil3.toBitmap
+import coil3.transform.CircleCropTransformation
+
+class MarkerIconView(
+    context: Context,
+    attrs: AttributeSet? = null
+) : View(context, attrs) {
+    private val fillPaint = Paint().apply {
+        style = Paint.Style.FILL
+    }
+    private val strokePaint = Paint().apply {
+        style = Paint.Style.STROKE
+        strokeWidth = STROKE_WIDTH
+    }
+    private val imageLoader = SingletonImageLoader.get(context)
+    private var bitmap: Bitmap? = null
+    private val bitmapRect = Rect()
+
+    override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+        val width = resolveSize(MARKER_WIDTH.dpToPx(), widthMeasureSpec)
+        val height = resolveSize(MARKER_HEIGHT.dpToPx(), heightMeasureSpec)
+        setMeasuredDimension(width, height)
+    }
+
+    override fun onDraw(canvas: Canvas) {
+        super.onDraw(canvas)
+
+        canvas.drawRect((width - STROKE_WIDTH) / 2f, width / 2f, (width + STROKE_WIDTH) / 2f, height.toFloat(), fillPaint)
+        bitmap?.let {
+            bitmapRect.set(0, 0, width, width)
+            canvas.drawBitmap(it, null, bitmapRect, null)
+            canvas.drawCircle(width / 2f, width / 2f, (width - STROKE_WIDTH) / 2f, strokePaint) // bitmap 테두리 그리기
+        } ?: canvas.drawCircle(width / 2f, width / 2f, width / 2f, fillPaint) // bitmap이 null이면 이미지 없이 원만 그려지도록
+    }
+
+    fun setPaintColor(@ColorInt color: Int) {
+        fillPaint.color = color
+        strokePaint.color = color
+    }
+
+    fun loadImage(url: String, onImageLoaded: () -> Unit) {
+        Log.d(TAG_LOG, "loader : $imageLoader")
+        val request = ImageRequest.Builder(context)
+            .data(url)
+            .allowHardware(false)
+            .transformations(CircleCropTransformation())
+            .listener(
+                onSuccess = { _, result ->
+                    Log.d(TAG_LOG, "onSuccess $result")
+                    bitmap = result.image.toBitmap()
+                    onImageLoaded()
+                },
+                onError = { _, error ->
+                    Log.d(TAG_LOG, "onError $error")
+                    onImageLoaded()
+                }
+            )
+            .build()
+
+        imageLoader.enqueue(request)
+    }
+
+    private fun Int.dpToPx() = (this * resources.displayMetrics.density).toInt()
+
+    companion object {
+        private const val TAG_LOG = "MarkerIconView"
+
+        private const val STROKE_WIDTH = 8f
+        private const val MARKER_WIDTH = 40
+        private const val MARKER_HEIGHT = 50
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -90,6 +90,7 @@ androidx-constraintlayout = { group = "androidx.constraintlayout", name = "const
 androidx-ui-viewbinding = { group = "androidx.compose.ui", name = "ui-viewbinding", version.ref = "uiViewbinding" }
 
 # Coil
+coil = { module = "io.coil-kt.coil3:coil", version.ref = "coil" }
 coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coil" }
 coil-network-okhttp = { module = "io.coil-kt.coil3:coil-network-okhttp", version.ref = "coil" }
 


### PR DESCRIPTION
## #️⃣연관된 이슈
> - resolved #61 

## 📝작업 내용 및 코드

`marker.icon = OverlayImage.fromView(markerIconView)`를 사용하여 커스텀한 뷰가 마커의 아이콘이 되도록 했습니다.

[마커 아이콘 뷰 만들기](https://cultured-lan-6c6.notion.site/API-13aea5e5fc1780e3a497fb5cdc4e2e9c?pvs=4)

바텀 내비게이션의 중앙 버튼을 누르면 현재 위치에 커스텀한 아이콘 뷰가 보여집니다.
현재 마커 아이콘의 이미지는 임의로 설정해둔 url이라 이후에는 다른 값으로 변경해야 합니다.

![1000009341](https://github.com/user-attachments/assets/36c02abd-aca1-4680-bdc8-e9e4851323cd)