### PR TITLE
[feature] 알림 반경 내 픽 개수 불러오기 

### DIFF
--- a/app/src/main/java/com/squirtles/musicroad/map/MapFragment.kt
+++ b/app/src/main/java/com/squirtles/musicroad/map/MapFragment.kt
@@ -76,6 +76,7 @@ class MapFragment : Fragment(), OnMapReadyCallback {
 
         // 테스트 : 네이버커넥트 기준 주변 5km 내 픽 정보 불러오기
         mapViewModel.fetchPickInArea(37.380324, 127.115282, 5.0 * 1000.0)
+        mapViewModel.requestPickNotificationArea(37.380324, 127.115282, CIRCLE_RADIUS_METER)
 
         lifecycleScope.launch {
             mapViewModel.centerButtonClick.collect {

--- a/app/src/main/java/com/squirtles/musicroad/map/MapFragment.kt
+++ b/app/src/main/java/com/squirtles/musicroad/map/MapFragment.kt
@@ -76,7 +76,6 @@ class MapFragment : Fragment(), OnMapReadyCallback {
 
         // 테스트 : 네이버커넥트 기준 주변 5km 내 픽 정보 불러오기
         mapViewModel.fetchPickInArea(37.380324, 127.115282, 5.0 * 1000.0)
-        mapViewModel.requestPickNotificationArea(37.380324, 127.115282, CIRCLE_RADIUS_METER)
 
         lifecycleScope.launch {
             mapViewModel.centerButtonClick.collect {
@@ -129,6 +128,7 @@ class MapFragment : Fragment(), OnMapReadyCallback {
         naverMap.addOnLocationChangeListener { location ->
             setCircleOverlay(location)
             mapViewModel.updateCurLocation(location)
+            mapViewModel.requestPickNotificationArea(location, CIRCLE_RADIUS_METER)
         }
     }
 

--- a/app/src/main/java/com/squirtles/musicroad/map/MapScreen.kt
+++ b/app/src/main/java/com/squirtles/musicroad/map/MapScreen.kt
@@ -11,19 +11,23 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.FavoriteBorder
 import androidx.compose.material.icons.outlined.AccountCircle
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -33,6 +37,7 @@ import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.FragmentContainerView
 import com.squirtles.musicroad.R
 import com.squirtles.musicroad.ui.theme.MusicRoadTheme
+import com.squirtles.musicroad.ui.theme.White
 
 @Composable
 fun MapScreen(
@@ -42,6 +47,7 @@ fun MapScreen(
     onSettingClick: () -> Unit
 ) {
     Log.d("MapScreen", mapViewModel.toString())
+    val pickCount = 1
 
     Scaffold(
         contentWindowInsets = WindowInsets.navigationBars
@@ -64,6 +70,10 @@ fun MapScreen(
                 }
             )
 
+            if (pickCount > 0) {
+                PickNotificationBanner(pickCount)
+            }
+
             BottomNavigation(
                 modifier = Modifier
                     .align(Alignment.BottomCenter)
@@ -73,6 +83,21 @@ fun MapScreen(
                 onSettingClick = onSettingClick
             )
         }
+    }
+}
+
+@Composable
+fun PickNotificationBanner(pickCount: Int) {
+    Box(Modifier.fillMaxSize()) {
+        Text(
+            text = stringResource(id = R.string.map_pick_notification, pickCount),
+            modifier = Modifier
+                .align(Alignment.TopCenter)
+                .offset(y = (LocalConfiguration.current.screenHeightDp * 0.08).dp)
+                .clip(RoundedCornerShape(30.dp))
+                .background(White.copy(alpha = 0.8f))
+                .padding(vertical = 10.dp, horizontal = 23.dp)
+        )
     }
 }
 
@@ -166,6 +191,14 @@ fun BottomNavigationDarkPreview() {
             onCenterClick = {},
             onSettingClick = {}
         )
+    }
+}
+
+@Preview
+@Composable
+private fun PickNotificationBannerPreview() {
+    MusicRoadTheme {
+        PickNotificationBanner(1)
     }
 }
 

--- a/app/src/main/java/com/squirtles/musicroad/map/MapScreen.kt
+++ b/app/src/main/java/com/squirtles/musicroad/map/MapScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -35,6 +36,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.FragmentContainerView
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.squirtles.musicroad.R
 import com.squirtles.musicroad.ui.theme.MusicRoadTheme
 import com.squirtles.musicroad.ui.theme.White
@@ -47,7 +49,7 @@ fun MapScreen(
     onSettingClick: () -> Unit
 ) {
     Log.d("MapScreen", mapViewModel.toString())
-    val pickCount = 1
+    val pickCount by mapViewModel.pickCount.collectAsStateWithLifecycle()
 
     Scaffold(
         contentWindowInsets = WindowInsets.navigationBars

--- a/app/src/main/java/com/squirtles/musicroad/map/MapViewModel.kt
+++ b/app/src/main/java/com/squirtles/musicroad/map/MapViewModel.kt
@@ -27,6 +27,9 @@ class MapViewModel @Inject constructor(
     private val _curLocation = MutableStateFlow<Location?>(null)
     val curLocation = _curLocation.asStateFlow()
 
+    private val _pickCount = MutableStateFlow(0)
+    val pickCount = _pickCount.asStateFlow()
+
     fun createMarker() {
         viewModelScope.launch {
             _centerButtonClick.emit(true)
@@ -65,6 +68,17 @@ class MapViewModel @Inject constructor(
             }
 
             Log.d("MapViewModel", picks.toString())
+        }
+    }
+
+    fun requestPickNotificationArea(lat: Double, lng: Double, notiRadius: Double) {
+        viewModelScope.launch {
+            fetchPickInAreaUseCase(lat, lng, notiRadius)
+                .onSuccess {
+                    _pickCount.emit(it.count())
+                }.onFailure {
+                    _pickCount.emit(0)
+                }
         }
     }
 }

--- a/app/src/main/java/com/squirtles/musicroad/map/MapViewModel.kt
+++ b/app/src/main/java/com/squirtles/musicroad/map/MapViewModel.kt
@@ -71,9 +71,9 @@ class MapViewModel @Inject constructor(
         }
     }
 
-    fun requestPickNotificationArea(lat: Double, lng: Double, notiRadius: Double) {
+    fun requestPickNotificationArea(location: Location, notiRadius: Double) {
         viewModelScope.launch {
-            fetchPickInAreaUseCase(lat, lng, notiRadius)
+            fetchPickInAreaUseCase(location.latitude, location.longitude, notiRadius)
                 .onSuccess {
                     _pickCount.emit(it.count())
                 }.onFailure {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,6 +8,7 @@
     <string name="map_navigation_favorite_icon_description">픽 보관함 이동 버튼 아이콘</string>
     <string name="map_navigation_setting_icon_description">설정 이동 버튼 아이콘</string>
     <string name="map_navigation_center_icon_description">내비게이션 중앙 버튼 아이콘</string>
+    <string name="map_pick_notification">💿 주변에 %d개의 픽이 있습니다!</string>
     <string name="map_info_window_album_description">앨범 이미지</string>
     <string name="map_info_window_pick_user">님의 픽</string>
     <string name="map_info_window_favorite_count_icon_description">픽을 담은 개수</string>


### PR DESCRIPTION
## #️⃣연관된 이슈

> - resolved: #48 

## 📝작업 내용 및 코드

- 픽 개수 배너 생성
- 픽 개수가 1개 이상일 때 알림 보여주기
- 알림 반경 내의 픽 개수만 요청
- 기기 화면의 세로 8%의 영역에 표시되도록 함 


### 화면 크기가 다른 기기

|<img width="276" src="https://github.com/user-attachments/assets/b5e3754b-d643-4e49-86e3-e86e3043b200">|<img width="287" src="https://github.com/user-attachments/assets/7db10406-7223-4e26-bca5-0c8708e27a28">|<img width="726" src="https://github.com/user-attachments/assets/d4fc6834-c0f8-43c8-9b5e-9f8d939553fd">|
|---|---|---|


### 알림 반경을 벗어나는 경우

(현재 지도에 픽 보여주기 기능이 구현 안 되어있으며, 네이버 커넥트 위치에 픽이 생성되어있는 점을 참고)

<img width="250" src="https://github.com/user-attachments/assets/be9ea7bc-0241-4023-a1ac-f047324bde9f">


