### PR TITLE
[feature] Swipe 제스처로 뮤직비디오 화면으로 전환

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -109,4 +109,9 @@ dependencies {
     implementation(libs.coil)
     implementation(libs.coil.compose)
     implementation(libs.coil.network.okhttp)
+
+    // ExoPlayer
+    implementation(libs.androidx.media3.exoplayer)
+    implementation(libs.androidx.media3.exoplayer.dash)
+    implementation(libs.androidx.media3.ui)
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -79,6 +79,7 @@ dependencies {
     implementation(libs.androidx.ui.viewbinding)
     implementation(libs.androidx.navigation.compose)
     implementation(libs.androidx.core.splashscreen)
+    implementation(libs.androidx.compose.material)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/java/com/squirtles/musicroad/pick/DetailPickScreen.kt
+++ b/app/src/main/java/com/squirtles/musicroad/pick/DetailPickScreen.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalConfiguration
@@ -97,14 +98,14 @@ fun DetailPickScreen(
     val username = "짱구"
     val isFavorite = false
     val pick by pickViewModel.pick.collectAsStateWithLifecycle()
-    var showMusicVideo by remember { mutableStateOf(false) }
+    var isMusicVideoAvailable by remember { mutableStateOf(false) }
 
     LaunchedEffect(Unit) {
         pickViewModel.fetchPick(pickId)
     }
 
     LaunchedEffect(pick) {
-        showMusicVideo = pick.musicVideoUrl.isNotEmpty()
+        isMusicVideoAvailable = pick.musicVideoUrl.isNotEmpty()
     }
 
     Box(modifier = Modifier.fillMaxSize()) {
@@ -113,22 +114,22 @@ fun DetailPickScreen(
             username = username,
             pick = pick,
             isFavorite = isFavorite,
-            showMusicVideo = showMusicVideo,
+            isMusicVideoAvailable = isMusicVideoAvailable,
             swipeableModifier = swipeableModifier,
             onBackClick = onBackClick
         )
 
-        if (showMusicVideo) {
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
+        if (isMusicVideoAvailable) {
+            val isPlaying = swipeableState.offset.value < contentHeightPx * 0.8f
+            val alpha = (1 - (swipeableState.offset.value / contentHeightPx)).coerceIn(0f, 1f)
+
+            MusicVideoScreen(
+                videoUri = pick.musicVideoUrl,
+                isPlaying = isPlaying,
+                modifier = swipeableModifier
                     .offset { IntOffset(0, swipeableState.offset.value.roundToInt()) }
-            ) {
-                MusicVideoScreen(
-                    videoUri = pick.musicVideoUrl,
-                    modifier = swipeableModifier
-                )
-            }
+                    .graphicsLayer { this.alpha = alpha }
+            )
         }
     }
 }
@@ -140,7 +141,7 @@ private fun DetailPickScreen(
     username: String,
     pick: Pick,
     isFavorite: Boolean,
-    showMusicVideo: Boolean,
+    isMusicVideoAvailable: Boolean,
     swipeableModifier: Modifier,
     onBackClick: () -> Unit,
 ) {
@@ -260,7 +261,7 @@ private fun DetailPickScreen(
                 )
             }
 
-            if (showMusicVideo) {
+            if (isMusicVideoAvailable) {
                 Box(
                     modifier = swipeableModifier
                         .fillMaxWidth()
@@ -327,7 +328,7 @@ private fun DetailPickScreenPreview() {
             musicVideoUrl = "",
         ),
         isFavorite = false,
-        showMusicVideo = true,
+        isMusicVideoAvailable = true,
         swipeableModifier = Modifier,
         onBackClick = {}
     )

--- a/app/src/main/java/com/squirtles/musicroad/pick/DetailPickScreen.kt
+++ b/app/src/main/java/com/squirtles/musicroad/pick/DetailPickScreen.kt
@@ -127,6 +127,7 @@ fun DetailPickScreen(
                 videoUri = pick.musicVideoUrl,
                 isPlaying = isPlaying,
                 modifier = swipeableModifier
+                    .fillMaxSize()
                     .offset { IntOffset(0, swipeableState.offset.value.roundToInt()) }
                     .graphicsLayer { this.alpha = alpha }
             )

--- a/app/src/main/java/com/squirtles/musicroad/pick/DetailPickScreen.kt
+++ b/app/src/main/java/com/squirtles/musicroad/pick/DetailPickScreen.kt
@@ -113,6 +113,7 @@ fun DetailPickScreen(
             username = username,
             pick = pick,
             isFavorite = isFavorite,
+            showMusicVideo = showMusicVideo,
             swipeableModifier = swipeableModifier,
             onBackClick = onBackClick
         )
@@ -139,6 +140,7 @@ private fun DetailPickScreen(
     username: String,
     pick: Pick,
     isFavorite: Boolean,
+    showMusicVideo: Boolean,
     swipeableModifier: Modifier,
     onBackClick: () -> Unit,
 ) {
@@ -258,17 +260,19 @@ private fun DetailPickScreen(
                 )
             }
 
-            Box(
-                modifier = swipeableModifier
-                    .fillMaxWidth()
-                    .heightIn(min = 100.dp)
-            ) {
-                Icon(
-                    painter = painterResource(id = R.drawable.ic_swipe),
-                    contentDescription = stringResource(id = R.string.pick_swipe_icon_description),
-                    modifier = Modifier.align(Alignment.Center),
-                    tint = White
-                )
+            if (showMusicVideo) {
+                Box(
+                    modifier = swipeableModifier
+                        .fillMaxWidth()
+                        .heightIn(min = 100.dp)
+                ) {
+                    Icon(
+                        painter = painterResource(id = R.drawable.ic_swipe),
+                        contentDescription = stringResource(id = R.string.pick_swipe_icon_description),
+                        modifier = Modifier.align(Alignment.Center),
+                        tint = White
+                    )
+                }
             }
         }
     }
@@ -323,6 +327,7 @@ private fun DetailPickScreenPreview() {
             musicVideoUrl = "",
         ),
         isFavorite = false,
+        showMusicVideo = true,
         swipeableModifier = Modifier,
         onBackClick = {}
     )

--- a/app/src/main/java/com/squirtles/musicroad/pick/DetailPickScreen.kt
+++ b/app/src/main/java/com/squirtles/musicroad/pick/DetailPickScreen.kt
@@ -109,15 +109,6 @@ fun DetailPickScreen(
         isMusicVideoAvailable = pick.musicVideoUrl.isNotEmpty()
     }
 
-    // 최초 Swipe 동작 전에 MusicVideoScreen이 생성되지 않도록 함
-    LaunchedEffect(swipeableState.offset.value) {
-        if (swipeableState.offset.value != 0.0f &&
-            contentHeightPx != swipeableState.offset.value
-        ) {
-            showMusicVideo = true
-        }
-    }
-
     Box(modifier = Modifier.fillMaxSize()) {
         DetailPickScreen(
             userId = userId,
@@ -128,6 +119,11 @@ fun DetailPickScreen(
             swipeableModifier = swipeableModifier,
             onBackClick = onBackClick
         )
+
+        // 최초 Swipe 동작 전에 MusicVideoScreen이 생성되지 않도록 함
+        if (swipeableState.offset.value != 0.0f && contentHeightPx != swipeableState.offset.value) {
+            showMusicVideo = true
+        }
 
         if (isMusicVideoAvailable && showMusicVideo) {
             val isPlaying = swipeableState.offset.value < contentHeightPx * 0.8f

--- a/app/src/main/java/com/squirtles/musicroad/pick/DetailPickScreen.kt
+++ b/app/src/main/java/com/squirtles/musicroad/pick/DetailPickScreen.kt
@@ -3,15 +3,20 @@ package com.squirtles.musicroad.pick
 import android.app.Activity
 import android.util.Size
 import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
@@ -37,16 +42,23 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.core.graphics.toColorInt
 import androidx.core.view.WindowInsetsControllerCompat
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.wear.compose.material.ExperimentalWearMaterialApi
+import androidx.wear.compose.material.FractionalThreshold
+import androidx.wear.compose.material.rememberSwipeableState
+import androidx.wear.compose.material.swipeable
 import coil3.compose.AsyncImage
 import com.squirtles.domain.model.Pick
 import com.squirtles.domain.model.PickLocation
@@ -56,13 +68,28 @@ import com.squirtles.musicroad.ui.theme.Black
 import com.squirtles.musicroad.ui.theme.Dark
 import com.squirtles.musicroad.ui.theme.Gray
 import com.squirtles.musicroad.ui.theme.White
+import kotlin.math.roundToInt
 
+@OptIn(ExperimentalWearMaterialApi::class)
 @Composable
 fun DetailPickScreen(
     pickId: String,
     onBackClick: () -> Unit,
     pickViewModel: PickViewModel = hiltViewModel(),
 ) {
+    val screenHeight = LocalConfiguration.current.screenHeightDp.dp
+    val screenHeightPx = with(LocalDensity.current) { screenHeight.toPx() }
+    val statusBarHeight = with(LocalDensity.current) { WindowInsets.statusBars.getTop(this) }
+    val contentHeightPx = screenHeightPx + statusBarHeight
+    val anchors = mapOf(contentHeightPx to 0, 0f to 1)
+    val swipeableState = rememberSwipeableState(initialValue = 0)
+    val swipeableModifier = Modifier.swipeable(
+        state = swipeableState,
+        anchors = anchors,
+        thresholds = { _, _ -> FractionalThreshold(0.3f) },
+        orientation = Orientation.Vertical
+    )
+
     val userId = ""
     val username = "짱구"
     val isFavorite = false
@@ -72,13 +99,26 @@ fun DetailPickScreen(
         pickViewModel.fetchPick(pickId)
     }
 
-    DetailPickScreen(
-        userId = userId,
-        username = username,
-        pick = pick,
-        isFavorite = isFavorite,
-        onBackClick = onBackClick
-    )
+    Box(modifier = Modifier.fillMaxSize()) {
+        DetailPickScreen(
+            userId = userId,
+            username = username,
+            pick = pick,
+            isFavorite = isFavorite,
+            swipeableModifier = swipeableModifier,
+            onBackClick = onBackClick
+        )
+
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .offset { IntOffset(0, swipeableState.offset.value.roundToInt()) }
+        ) {
+            MusicVideoScreen(
+                modifier = swipeableModifier
+            )
+        }
+    }
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -88,6 +128,7 @@ private fun DetailPickScreen(
     username: String,
     pick: Pick,
     isFavorite: Boolean,
+    swipeableModifier: Modifier,
     onBackClick: () -> Unit,
 ) {
     val isMine = userId == pick.createdBy
@@ -144,7 +185,7 @@ private fun DetailPickScreen(
         }
     ) { innerPadding ->
 
-        Box(
+        Column(
             modifier = Modifier
                 .fillMaxSize()
                 .background(
@@ -156,12 +197,13 @@ private fun DetailPickScreen(
                     )
                 )
                 .padding(innerPadding)
+                .verticalScroll(scrollState),
+            verticalArrangement = Arrangement.SpaceBetween
         ) {
             Column(
                 modifier = Modifier
                     .fillMaxSize()
-                    .verticalScroll(scrollState)
-                    .padding(vertical = 10.dp),
+                    .padding(top = 10.dp),
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.spacedBy(10.dp),
             ) {
@@ -201,6 +243,19 @@ private fun DetailPickScreen(
                         .verticalScroll(scrollState)
                         .padding(horizontal = 12.dp, vertical = 8.dp),
                     style = MaterialTheme.typography.bodyLarge.copy(White)
+                )
+            }
+
+            Box(
+                modifier = swipeableModifier
+                    .fillMaxWidth()
+                    .heightIn(min = 100.dp)
+            ) {
+                Icon(
+                    painter = painterResource(id = R.drawable.ic_swipe),
+                    contentDescription = stringResource(id = R.string.pick_swipe_icon_description),
+                    modifier = Modifier.align(Alignment.Center),
+                    tint = White
                 )
             }
         }
@@ -256,6 +311,7 @@ private fun DetailPickScreenPreview() {
             musicVideoUrl = "",
         ),
         isFavorite = false,
+        swipeableModifier = Modifier,
         onBackClick = {}
     )
 }

--- a/app/src/main/java/com/squirtles/musicroad/pick/DetailPickScreen.kt
+++ b/app/src/main/java/com/squirtles/musicroad/pick/DetailPickScreen.kt
@@ -99,6 +99,7 @@ fun DetailPickScreen(
     val isFavorite = false
     val pick by pickViewModel.pick.collectAsStateWithLifecycle()
     var isMusicVideoAvailable by remember { mutableStateOf(false) }
+    var showMusicVideo by remember { mutableStateOf(false) }
 
     LaunchedEffect(Unit) {
         pickViewModel.fetchPick(pickId)
@@ -106,6 +107,15 @@ fun DetailPickScreen(
 
     LaunchedEffect(pick) {
         isMusicVideoAvailable = pick.musicVideoUrl.isNotEmpty()
+    }
+
+    // 최초 Swipe 동작 전에 MusicVideoScreen이 생성되지 않도록 함
+    LaunchedEffect(swipeableState.offset.value) {
+        if (swipeableState.offset.value != 0.0f &&
+            contentHeightPx != swipeableState.offset.value
+        ) {
+            showMusicVideo = true
+        }
     }
 
     Box(modifier = Modifier.fillMaxSize()) {
@@ -119,7 +129,7 @@ fun DetailPickScreen(
             onBackClick = onBackClick
         )
 
-        if (isMusicVideoAvailable) {
+        if (isMusicVideoAvailable && showMusicVideo) {
             val isPlaying = swipeableState.offset.value < contentHeightPx * 0.8f
             val alpha = (1 - (swipeableState.offset.value / contentHeightPx)).coerceIn(0f, 1f)
 

--- a/app/src/main/java/com/squirtles/musicroad/pick/DetailPickScreen.kt
+++ b/app/src/main/java/com/squirtles/musicroad/pick/DetailPickScreen.kt
@@ -34,6 +34,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -94,9 +97,14 @@ fun DetailPickScreen(
     val username = "짱구"
     val isFavorite = false
     val pick by pickViewModel.pick.collectAsStateWithLifecycle()
+    var showMusicVideo by remember { mutableStateOf(false) }
 
     LaunchedEffect(Unit) {
         pickViewModel.fetchPick(pickId)
+    }
+
+    LaunchedEffect(pick) {
+        showMusicVideo = pick.musicVideoUrl.isNotEmpty()
     }
 
     Box(modifier = Modifier.fillMaxSize()) {
@@ -109,14 +117,17 @@ fun DetailPickScreen(
             onBackClick = onBackClick
         )
 
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .offset { IntOffset(0, swipeableState.offset.value.roundToInt()) }
-        ) {
-            MusicVideoScreen(
-                modifier = swipeableModifier
-            )
+        if (showMusicVideo) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .offset { IntOffset(0, swipeableState.offset.value.roundToInt()) }
+            ) {
+                MusicVideoScreen(
+                    videoUri = pick.musicVideoUrl,
+                    modifier = swipeableModifier
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/squirtles/musicroad/pick/MusicVideoScreen.kt
+++ b/app/src/main/java/com/squirtles/musicroad/pick/MusicVideoScreen.kt
@@ -1,8 +1,12 @@
 package com.squirtles.musicroad.pick
 
+import android.graphics.Matrix
+import android.graphics.SurfaceTexture
+import android.view.Surface
+import android.view.TextureView
 import androidx.annotation.OptIn
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -10,10 +14,7 @@ import androidx.compose.ui.viewinterop.AndroidView
 import androidx.media3.common.MediaItem
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.ExoPlayer
-import androidx.media3.ui.AspectRatioFrameLayout
-import androidx.media3.ui.PlayerView
 
-@OptIn(UnstableApi::class)
 @Composable
 fun MusicVideoScreen(
     videoUri: String,
@@ -21,20 +22,59 @@ fun MusicVideoScreen(
     modifier: Modifier
 ) {
     val context = LocalContext.current
-    val playerView = remember { PlayerView(context) }
     val player = remember { ExoPlayer.Builder(context).build() }
+    val textureView = remember { TextureView(context) }
+
+    DisposableEffect(Unit) {
+        onDispose {
+            player.release()
+        }
+    }
 
     AndroidView(
         factory = {
-            playerView.apply {
-                this.player = player
-                this.resizeMode = AspectRatioFrameLayout.RESIZE_MODE_ZOOM
-                val mediaItem = MediaItem.fromUri(videoUri)
-                player.setMediaItem(mediaItem)
-                player.prepare()
+            textureView.apply {
+                surfaceTextureListener = object : TextureView.SurfaceTextureListener {
+                    @OptIn(UnstableApi::class)
+                    override fun onSurfaceTextureAvailable(
+                        surfaceTexture: SurfaceTexture,
+                        width: Int,
+                        height: Int
+                    ) {
+                        val surface = Surface(surfaceTexture)
+                        val mediaItem = MediaItem.fromUri(videoUri)
+                        player.setVideoSurface(surface)
+                        player.setMediaItem(mediaItem)
+                        player.prepare()
+
+                        // 영상을 화면 크기에 맞게 확대
+                        val matrix = Matrix()
+                        val scaleFactor = height.toFloat() / width.toFloat()
+                        matrix.setScale(scaleFactor, 1f)
+
+                        // 영상 중앙 정렬
+                        val translateX = (width - width * scaleFactor) / 2f
+                        matrix.postTranslate(translateX, 0f)
+                        textureView.setTransform(matrix)
+
+                    }
+
+                    override fun onSurfaceTextureSizeChanged(
+                        surfaceTexture: SurfaceTexture,
+                        width: Int,
+                        height: Int
+                    ) = Unit
+
+                    override fun onSurfaceTextureDestroyed(surfaceTexture: SurfaceTexture): Boolean {
+                        player.setVideoSurface(null)
+                        return true
+                    }
+
+                    override fun onSurfaceTextureUpdated(surfaceTexture: SurfaceTexture) = Unit
+                }
             }
         },
-        modifier = modifier.fillMaxSize()
+        modifier = modifier
     ) {
         if (isPlaying) player.play()
         else player.pause()

--- a/app/src/main/java/com/squirtles/musicroad/pick/MusicVideoScreen.kt
+++ b/app/src/main/java/com/squirtles/musicroad/pick/MusicVideoScreen.kt
@@ -1,0 +1,26 @@
+package com.squirtles.musicroad.pick
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.sp
+import com.squirtles.musicroad.ui.theme.Purple15
+import com.squirtles.musicroad.ui.theme.White
+
+@Composable
+fun MusicVideoScreen(
+    modifier: Modifier
+) {
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(Purple15),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(text = "다음 화면", color = White, fontSize = 24.sp)
+    }
+}

--- a/app/src/main/java/com/squirtles/musicroad/pick/MusicVideoScreen.kt
+++ b/app/src/main/java/com/squirtles/musicroad/pick/MusicVideoScreen.kt
@@ -1,45 +1,42 @@
 package com.squirtles.musicroad.pick
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
+import androidx.annotation.OptIn
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.media3.common.MediaItem
+import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.ui.AspectRatioFrameLayout
 import androidx.media3.ui.PlayerView
-import com.squirtles.musicroad.ui.theme.Purple15
 
+@OptIn(UnstableApi::class)
 @Composable
 fun MusicVideoScreen(
     videoUri: String,
+    isPlaying: Boolean,
     modifier: Modifier
 ) {
     val context = LocalContext.current
     val playerView = remember { PlayerView(context) }
     val player = remember { ExoPlayer.Builder(context).build() }
 
-    Box(
-        modifier = modifier
-            .fillMaxSize()
-            .background(Purple15),
-        contentAlignment = Alignment.Center
+    AndroidView(
+        factory = {
+            playerView.apply {
+                this.player = player
+                this.resizeMode = AspectRatioFrameLayout.RESIZE_MODE_ZOOM
+                val mediaItem = MediaItem.fromUri(videoUri)
+                player.setMediaItem(mediaItem)
+                player.prepare()
+            }
+        },
+        modifier = modifier.fillMaxSize()
     ) {
-        AndroidView(
-            factory = {
-                playerView.apply {
-                    this.player = player
-                    val mediaItem = MediaItem.fromUri(videoUri)
-                    player.setMediaItem(mediaItem)
-                    player.prepare()
-                    player.play()
-                }
-            },
-            modifier = Modifier.fillMaxSize()
-        )
+        if (isPlaying) player.play()
+        else player.pause()
     }
 }

--- a/app/src/main/java/com/squirtles/musicroad/pick/MusicVideoScreen.kt
+++ b/app/src/main/java/com/squirtles/musicroad/pick/MusicVideoScreen.kt
@@ -3,24 +3,43 @@ package com.squirtles.musicroad.pick
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.sp
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.media3.common.MediaItem
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.ui.PlayerView
 import com.squirtles.musicroad.ui.theme.Purple15
-import com.squirtles.musicroad.ui.theme.White
 
 @Composable
 fun MusicVideoScreen(
+    videoUri: String,
     modifier: Modifier
 ) {
+    val context = LocalContext.current
+    val playerView = remember { PlayerView(context) }
+    val player = remember { ExoPlayer.Builder(context).build() }
+
     Box(
         modifier = modifier
             .fillMaxSize()
             .background(Purple15),
         contentAlignment = Alignment.Center
     ) {
-        Text(text = "다음 화면", color = White, fontSize = 24.sp)
+        AndroidView(
+            factory = {
+                playerView.apply {
+                    this.player = player
+                    val mediaItem = MediaItem.fromUri(videoUri)
+                    player.setMediaItem(mediaItem)
+                    player.prepare()
+                    player.play()
+                }
+            },
+            modifier = Modifier.fillMaxSize()
+        )
     }
 }

--- a/app/src/main/java/com/squirtles/musicroad/pick/MusicVideoScreen.kt
+++ b/app/src/main/java/com/squirtles/musicroad/pick/MusicVideoScreen.kt
@@ -15,6 +15,7 @@ import androidx.media3.common.MediaItem
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.ExoPlayer
 
+@OptIn(UnstableApi::class)
 @Composable
 fun MusicVideoScreen(
     videoUri: String,
@@ -35,42 +36,28 @@ fun MusicVideoScreen(
         factory = {
             textureView.apply {
                 surfaceTextureListener = object : TextureView.SurfaceTextureListener {
-                    @OptIn(UnstableApi::class)
-                    override fun onSurfaceTextureAvailable(
-                        surfaceTexture: SurfaceTexture,
-                        width: Int,
-                        height: Int
-                    ) {
+                    override fun onSurfaceTextureAvailable(surfaceTexture: SurfaceTexture, width: Int, height: Int) {
                         val surface = Surface(surfaceTexture)
                         val mediaItem = MediaItem.fromUri(videoUri)
                         player.setVideoSurface(surface)
                         player.setMediaItem(mediaItem)
                         player.prepare()
 
-                        // 영상을 화면 크기에 맞게 확대
-                        val matrix = Matrix()
-                        val scaleFactor = height.toFloat() / width.toFloat()
-                        matrix.setScale(scaleFactor, 1f)
-
-                        // 영상 중앙 정렬
-                        val translateX = (width - width * scaleFactor) / 2f
-                        matrix.postTranslate(translateX, 0f)
-                        textureView.setTransform(matrix)
-
+                        setVideoSize(width, height, textureView)
                     }
 
-                    override fun onSurfaceTextureSizeChanged(
-                        surfaceTexture: SurfaceTexture,
-                        width: Int,
-                        height: Int
-                    ) = Unit
+                    override fun onSurfaceTextureSizeChanged(surfaceTexture: SurfaceTexture, width: Int, height: Int) {
+                        // TODO
+                    }
 
                     override fun onSurfaceTextureDestroyed(surfaceTexture: SurfaceTexture): Boolean {
                         player.setVideoSurface(null)
                         return true
                     }
 
-                    override fun onSurfaceTextureUpdated(surfaceTexture: SurfaceTexture) = Unit
+                    override fun onSurfaceTextureUpdated(surfaceTexture: SurfaceTexture) {
+                        // TODO
+                    }
                 }
             }
         },
@@ -79,4 +66,16 @@ fun MusicVideoScreen(
         if (isPlaying) player.play()
         else player.pause()
     }
+}
+
+private fun setVideoSize(width: Int, height: Int, textureView: TextureView) {
+    // 영상을 화면 크기에 맞게 확대
+    val matrix = Matrix()
+    val scaleFactor = height.toFloat() / width.toFloat()
+    matrix.setScale(scaleFactor, 1f)
+
+    // 영상 중앙 정렬
+    val translateX = (width - width * scaleFactor) / 2f
+    matrix.postTranslate(translateX, 0f)
+    textureView.setTransform(matrix)
 }

--- a/app/src/main/res/drawable/ic_swipe.xml
+++ b/app/src/main/res/drawable/ic_swipe.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:pathData="M18 11l-6-6-6 6m12 9l-6-6-6 6"
+        android:strokeWidth="2"
+        android:strokeColor="#FFFFFFFF"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round" />
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -24,6 +24,7 @@
     <string name="pick_favorite_true_icon_description">담은 픽</string>
     <string name="pick_favorite_false_icon_description">픽 담기</string>
     <string name="pick_favorite_count_icon_description">픽을 담은 개수</string>
+    <string name="pick_swipe_icon_description">위로 밀어 뮤직비디오 보기</string>
 
     <!-- Search Music -->
     <string name="search_music_album_description">노래 앨범 이미지</string>

--- a/data/src/main/java/com/squirtles/data/mapper/FirebaseMapper.kt
+++ b/data/src/main/java/com/squirtles/data/mapper/FirebaseMapper.kt
@@ -33,13 +33,14 @@ internal fun FirebasePick.toPick(): Pick = Pick(
         previewUrl = previewUrl.toString(),
     ),
     comment = comment.toString(),
-    createdAt = createdAt?.toDate()?.formatTimestamp() ?: "",
+    favoriteCount = favoriteCount,
     createdBy = createdBy.toString(),
+    createdAt = createdAt?.toDate()?.formatTimestamp() ?: "",
     location = PickLocation(
         latitude = location?.latitude ?: 0.0,
         longitude = location?.longitude ?: 0.0
     ),
-    favoriteCount = favoriteCount,
+    musicVideoUrl = musicVideoUrl ?: ""
 )
 
 /**

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,6 +29,7 @@ playServicesLocation = "21.3.0"
 retrofit = "2.11.0"
 splashscreen = "1.0.1"
 uiViewbinding = "1.7.5"
+composeMaterial = "1.4.0"
 
 [libraries]
 # AndroidX
@@ -50,12 +51,12 @@ androidx-material3 = { group = "androidx.compose.material3", name = "material3" 
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "navigationCompose" }
 androidx-core-splashscreen = { module = "androidx.core:core-splashscreen", version.ref = "splashscreen" }
+androidx-compose-material = { group = "androidx.wear.compose", name = "compose-material", version.ref = "composeMaterial" }
 
 # Firebase
 firebase-analytics = { module = "com.google.firebase:firebase-analytics" }
 firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebaseBom" }
 firebase-firestore-ktx = { group = "com.google.firebase", name = "firebase-firestore-ktx", version.ref = "firebaseFirestoreKtx" }
-
 
 # Test
 geofire-android-common = { module = "com.firebase:geofire-android-common", version.ref = "geofireAndroidCommon" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,6 +23,7 @@ ksp = "1.9.0-1.0.12"
 lifecycleRuntimeKtx = "2.8.7"
 mapSdk = "3.19.1"
 material = "1.12.0"
+media3Ui = "1.4.1"
 navigationCompose = "2.8.3"
 okhttp = "4.12.0"
 playServicesLocation = "21.3.0"
@@ -41,6 +42,9 @@ androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-co
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
+androidx-media3-exoplayer = { module = "androidx.media3:media3-exoplayer", version.ref = "media3Ui" }
+androidx-media3-exoplayer-dash = { module = "androidx.media3:media3-exoplayer-dash", version.ref = "media3Ui" }
+androidx-media3-ui = { module = "androidx.media3:media3-ui", version.ref = "media3Ui" }
 androidx-ui = { group = "androidx.compose.ui", name = "ui" }
 androidx-ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }
 androidx-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }


### PR DESCRIPTION
## #️⃣연관된 이슈

> - resolved: #89 

## 📝작업 내용 및 코드

- [구현 과정 링크입니다. ](https://cultured-lan-6c6.notion.site/Swipe-142ea5e5fc1780bdb490ea09c310e5fc?pvs=4)
- 구현 내용
  1. 픽 정보 화면에서 뮤직비디오 정보가 있는 경우 아이콘이 보인다.
  2. 스와이프 시 영상이 불투명해지면서 뮤직비디오가 재생된다. 
  3. 다시 아래로 스와이프 시 투명해지면서 뮤직비디오가 멈춘다.

### 작업 결과
(용량이 커서 로딩이 오래 걸리는 경우 노션으로 확인해주세요!)

![Nov-21-2024 17-12-15](https://github.com/user-attachments/assets/e8122fef-5b0a-40de-b6ab-434fae0f0f90)

## 💬리뷰 요구사항(선택)

- AndroidView의 swipeable의 영역이 불안정합니다. 
  - 위쪽만 스와이프되고 가끔은 아래도 되는 현상이 발생합니다. 이 부분도 추후 해결하겠습니다! 
- 구현하다보니 영상관련 처리할 이슈들이 추가적으로 보이네요.. 이번 이슈는 화면 전환 위주로 봐주시면 감사하겠습니다! 