### PR TITLE
[feature] 음악 검색 결과 자동으로 표시

### DIFF
--- a/app/src/main/java/com/squirtles/musicroad/UiState.kt
+++ b/app/src/main/java/com/squirtles/musicroad/UiState.kt
@@ -1,0 +1,8 @@
+package com.squirtles.musicroad
+
+sealed class UiState<out T> {
+    data object Init: UiState<Nothing>()
+    data class Loading<T>(val prevData: T?): UiState<T>()
+    data class Success<T>(val data: T): UiState<T>()
+    data object Error : UiState<Nothing>()
+}

--- a/app/src/main/java/com/squirtles/musicroad/create/CreatePickViewModel.kt
+++ b/app/src/main/java/com/squirtles/musicroad/create/CreatePickViewModel.kt
@@ -64,11 +64,11 @@ class CreatePickViewModel @Inject constructor(
             _searchText
                 .debounce(300)
                 .collect { searchKeyword ->
+                    searchJob?.cancel()
                     if (searchKeyword.isBlank()) {
                         searchResult = null
                         _searchUiState.value = UiState.Init
                     } else {
-                        searchJob?.cancel()
                         searchJob = launch { searchSongs(searchKeyword) }
                     }
                 }

--- a/app/src/main/java/com/squirtles/musicroad/create/CreatePickViewModel.kt
+++ b/app/src/main/java/com/squirtles/musicroad/create/CreatePickViewModel.kt
@@ -72,13 +72,6 @@ class CreatePickViewModel @Inject constructor(
         }
     }
 
-    fun searchSongs() {
-        searchJob?.cancel()
-        searchJob = viewModelScope.launch {
-            searchSongs(_searchText.value)
-        }
-    }
-
     private suspend fun searchSongs(searchKeyword: String) {
         _searchUiState.value = UiState.Loading(searchResult)
         val result = searchSongsUseCase(searchKeyword)

--- a/app/src/main/java/com/squirtles/musicroad/create/CreatePickViewModel.kt
+++ b/app/src/main/java/com/squirtles/musicroad/create/CreatePickViewModel.kt
@@ -40,9 +40,6 @@ class CreatePickViewModel @Inject constructor(
     private val _searchText = MutableStateFlow("")
     val searchText = _searchText.asStateFlow()
 
-    private val _isSearching = MutableStateFlow<Boolean>(false)
-    val isSearching = _isSearching.asStateFlow()
-
     private var searchResult: List<Song>? = null
     private var searchJob: Job? = null
 
@@ -90,6 +87,7 @@ class CreatePickViewModel @Inject constructor(
             searchResult = it
             _searchUiState.value = UiState.Success(it)
         }.onFailure {
+            searchResult = null
             _searchUiState.value = UiState.Error // NotFoundException(message=No such resource)
         }
     }
@@ -108,7 +106,6 @@ class CreatePickViewModel @Inject constructor(
 
     fun onSearchTextChange(text: String) {
         _searchText.value = text
-        _isSearching.value = true
     }
 
     fun createPick(

--- a/app/src/main/java/com/squirtles/musicroad/create/SearchMusicScreen.kt
+++ b/app/src/main/java/com/squirtles/musicroad/create/SearchMusicScreen.kt
@@ -75,7 +75,6 @@ fun SearchMusicScreen(
 
     val uiState by createPickViewModel.searchUiState.collectAsStateWithLifecycle()
     val searchText by createPickViewModel.searchText.collectAsStateWithLifecycle()
-    val isSearching by createPickViewModel.isSearching.collectAsStateWithLifecycle()
 
     Scaffold(
         contentWindowInsets = WindowInsets.navigationBars,
@@ -89,7 +88,6 @@ fun SearchMusicScreen(
                 SearchTopBar(
                     keyword = searchText,
                     onValueChange = createPickViewModel::onSearchTextChange,
-                    active = isSearching,
                     onSearchClick = createPickViewModel::searchSongs,
                     onBackClick = onBackClick,
                     focusManager = focusManager
@@ -151,7 +149,6 @@ fun SearchMusicScreen(
 private fun SearchTopBar(
     keyword: String,
     onValueChange: (String) -> Unit,
-    active: Boolean, // whether the user is searching or not
     onSearchClick: () -> Unit,
     onBackClick: () -> Boolean,
     focusManager: FocusManager

--- a/app/src/main/java/com/squirtles/musicroad/create/SearchMusicScreen.kt
+++ b/app/src/main/java/com/squirtles/musicroad/create/SearchMusicScreen.kt
@@ -88,7 +88,6 @@ fun SearchMusicScreen(
                 SearchTopBar(
                     keyword = searchText,
                     onValueChange = createPickViewModel::onSearchTextChange,
-                    onSearchClick = createPickViewModel::searchSongs,
                     onBackClick = onBackClick,
                     focusManager = focusManager
                 )
@@ -149,7 +148,6 @@ fun SearchMusicScreen(
 private fun SearchTopBar(
     keyword: String,
     onValueChange: (String) -> Unit,
-    onSearchClick: () -> Unit,
     onBackClick: () -> Boolean,
     focusManager: FocusManager
 ) {
@@ -190,7 +188,6 @@ private fun SearchTopBar(
             keyboardActions = KeyboardActions(
                 onSearch = {
                     focusManager.clearFocus()
-                    onSearchClick()
                 }
             ),
             singleLine = true,

--- a/app/src/main/java/com/squirtles/musicroad/create/SearchMusicScreen.kt
+++ b/app/src/main/java/com/squirtles/musicroad/create/SearchMusicScreen.kt
@@ -27,9 +27,9 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
@@ -91,8 +91,8 @@ fun SearchMusicScreen(
                     onValueChange = createPickViewModel::onSearchTextChange,
                     active = isSearching,
                     onSearchClick = createPickViewModel::searchSongs,
-                    focusManager = focusManager,
                     onBackClick = onBackClick,
+                    focusManager = focusManager
                 )
             }
         },
@@ -111,6 +111,12 @@ fun SearchMusicScreen(
                 }
 
                 is UiState.Loading -> {
+                    LinearProgressIndicator(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(top = 10.dp),
+                        trackColor = Gray
+                    )
                     (uiState as UiState.Loading).prevData?.let {
                         SearchResult(
                             searchResult = it,
@@ -175,27 +181,10 @@ private fun SearchTopBar(
         OutlinedTextField(
             value = keyword,
             onValueChange = onValueChange,
-            modifier = Modifier
-                .weight(1f),
+            modifier = Modifier.weight(1f),
             placeholder = {
                 Text("검색")
             },
-            trailingIcon = if (active) {
-                {
-                    IconButton(
-                        onClick = {
-                            focusManager.clearFocus()
-                            onSearchClick()
-                        }
-                    ) {
-                        Icon(
-                            imageVector = Icons.Default.Search,
-                            contentDescription = stringResource(R.string.search_music_search_button_description),
-                            tint = White
-                        )
-                    }
-                }
-            } else null,
             // 키보드 완료버튼 -> Search로 변경, 누르면 Search 동작 실행
             keyboardOptions = KeyboardOptions(
                 keyboardType = KeyboardType.Text,


### PR DESCRIPTION
## #️⃣연관된 이슈
- resolved: #100 

## 📝작업 내용 및 코드
- 자동으로 음악 검색 결과 표시

https://github.com/user-attachments/assets/68f246de-5a84-44ce-a5ea-c19689cfaf32

### UiState 정의
초기 상태, 로딩 상태, 성공 상태, 에러 상태로 구분하여 UiState를 정의하고, 이 상태에 따라 보여지는 화면을 관리했다.
```kotlin
sealed class UiState<out T> {
    data object Init: UiState<Nothing>()
    data object Loading: UiState<Nothing>()
    data class Success<T>(val data: T): UiState<T>()
    data object Error : UiState<Nothing>()
}
```

### 자동으로 음악 검색 결과 표시
처음에는 입력되는 텍스트에 따른 검색 결과를 자동으로 보여주기 위해 별 생각 없이 검색어가 바뀔 때마다 요청을 보냈다. 즉 모든 입력 값에 대해 검색 요청을 보냈다.

```kotlin
fun onSearchTextChange(text: String) {
    _searchText.value = text
    if (_searchText.value.isNotBlank()) {
        searchSongs()
    } else {
        _searchUiState.value = UiState.Init
    }
}
```

아이유를 검색한다고 해보자. 아이유를 검색한다는 것은 아이유에 대한 검색 결과를 보고 싶을 것인데 입력이 변할 때마다 요청을 보냈기 때문에 아이유를 검색하는 동안 여러 번의 검색 요청이 수행되었다.

![image (5)](https://github.com/user-attachments/assets/9b4c8833-ad04-4378-9c6c-b7fdaeb47b3e)

얻어온 검색 결과에 따라 화면에 보여지는 것도 달라지기 때문에 화면이 자주 변했다.

https://github.com/user-attachments/assets/ba1a2a8f-41d4-45b9-a1a2-6b31fb239ca7

심지어 아이유를 검색했는데 이전 요청이 나중 요청보다 먼저 처리되어 검색 결과가 이상한 경우도 있었다.

![image (6)](https://github.com/user-attachments/assets/ee82dcdb-dc2d-439b-9c92-000e3cae5c09)
<img src="https://github.com/user-attachments/assets/031234c0-d14b-4156-929b-cc0095b20729" width="300">

빠르게 입력할 때는 그 사이의 검색어에 대한 요청이 필요없기에 debounce를 사용하여 모든 검색어에 대해 검색 요청을 보내지 않도록 했다. debounce는 발생하는 이벤트를 그룹화하여 일정 시간 동안 이벤트가 발생하지 않았을 때 마지막 이벤트를 전달하는 것이다.

![image (5)](https://github.com/user-attachments/assets/2309c66d-5610-44a7-b118-fec59696c155)

debounce를 사용하여 0.3초 동안 입력되지 않을 때만 검색 요청을 보내서 너무 많은 요청을 하지 않도록 할 수 있었다.

```kotlin
viewModelScope.launch {
    _searchText
        .debounce(300)
        .collect { searchKeyword ->
            // 검색 요청
        }
}
```

다시 아이유를 검색했을 때는 아이유에 대한 검색 결과 하나만 받아오는 것을 확인했다.

![image (6)](https://github.com/user-attachments/assets/7975781a-9e06-4245-8218-8f6be6e91c82)

아이유를 검색한 후에 빠르게 지우고 데이식스를 입력했을 때 아이유의 검색 결과와 데이식스의 검색 결과 두 개만 받아오는 것도 확인했다.

![image (7)](https://github.com/user-attachments/assets/6bb74fb8-aae0-4f5b-931c-9c6c07ae1ba8)

검색어가 바뀌게 되면 로딩 상태가 되는데 로딩 중일 때 화면이 비는 게 마음에 들지 않았다. 검색어가 빈 상태에서 검색하는 게 아니라면 로딩되는 동안 이전의 데이터가 남아있었으면 했다. 아이를 검색하고 유를 붙여 아이유를 검색할 때 아이→아이유 그 사이 로딩 때 화면이 비어있었다.

https://github.com/user-attachments/assets/c2178ac7-4504-4262-afa2-2dd87123ab39


기존 UiState의 Loading에는 아무 값을 가지고 있지 않았는데 이전 데이터 값을 가지도록 하여 이전 데이터가 있으면 로딩 중에 이전 데이터가 보이도록 했다.

```kotlin
sealed class UiState<out T> {
    data object Init: UiState<Nothing>()
    data class Loading<T>(val prevData: T?): UiState<T>()
    data class Success<T>(val data: T): UiState<T>()
    data object Error : UiState<Nothing>()
}
```

```kotlin
is UiState.Loading -> {
    (uiState as UiState.Loading).prevData?.let {
        SearchResult(
            focusManager = focusManager,
            searchResult = it,
            onItemClick = { song ->
                createPickViewModel.onSongItemClick(song)
                onItemClick()
            }
        )
    }
}
```

https://github.com/user-attachments/assets/1d3e1e4f-de3b-46b9-b286-fe0a3b788a6a


또한 데이터가 로딩 중일 때 사용자가 로딩 중인지를 파악하는 게 어려워서 로딩 중일 때 검색 바 아래에 로딩 인디케이터를 추가해주었고, 자동으로 검색을 수행함에 따라 trailing icon을 제거했다. 최종 결과는 가장 상단에 첨부한 영상과 같다.

## 💬리뷰 요구사항
- (요구사항은 아닌 것 같지만..) trailing icon으로 전체 텍스트를 삭제하는 것을 하려 했는데 키보드가 자꾸 내려가는 문제가 있어서 일단은 trailing icon을 없애뒀습니다.
