### PR TITLE
[feature] 내가 등록한 픽 삭제 및 일부 화면 UiState 적용

### DIFF
--- a/app/src/main/java/com/squirtles/musicroad/UiState.kt
+++ b/app/src/main/java/com/squirtles/musicroad/UiState.kt
@@ -1,8 +1,0 @@
-package com.squirtles.musicroad
-
-sealed class UiState<out T> {
-    data object Init: UiState<Nothing>()
-    data class Loading<T>(val prevData: T?): UiState<T>()
-    data class Success<T>(val data: T): UiState<T>()
-    data object Error : UiState<Nothing>()
-}

--- a/app/src/main/java/com/squirtles/musicroad/common/CreatedByPickText.kt
+++ b/app/src/main/java/com/squirtles/musicroad/common/CreatedByPickText.kt
@@ -1,0 +1,50 @@
+package com.squirtles.musicroad.common
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextOverflow
+import com.squirtles.musicroad.R
+
+@Composable
+fun CreatedBySelfText(
+    modifier: Modifier = Modifier,
+    color: Color = MaterialTheme.colorScheme.onSurface,
+    style: TextStyle = MaterialTheme.typography.bodyMedium
+) {
+    Text(
+        text = stringResource(R.string.pick_created_by_self),
+        modifier = modifier,
+        color = color,
+        overflow = TextOverflow.Ellipsis,
+        maxLines = 1,
+        style = style,
+    )
+}
+
+@Composable
+fun CreatedByOtherUserText(
+    userName: String,
+    modifier: Modifier = Modifier,
+    color: Color = MaterialTheme.colorScheme.onSurface,
+    style: TextStyle = MaterialTheme.typography.bodyMedium
+) {
+    Text(
+        text = userName,
+        modifier = modifier,
+        color = color,
+        overflow = TextOverflow.Ellipsis,
+        maxLines = 1,
+        style = style,
+    )
+
+    Text(
+        text = stringResource(id = R.string.map_info_window_pick_user),
+        color = color,
+        style = style,
+    )
+}

--- a/app/src/main/java/com/squirtles/musicroad/create/CreatePickScreen.kt
+++ b/app/src/main/java/com/squirtles/musicroad/create/CreatePickScreen.kt
@@ -31,7 +31,9 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -64,6 +66,13 @@ fun CreatePickScreen(
 ) {
     val song = createPickViewModel.selectedSong ?: DEFAULT_SONG
     val comment = createPickViewModel.comment.collectAsStateWithLifecycle()
+    val createdPickId by createPickViewModel.createdPickId.collectAsStateWithLifecycle()
+
+    LaunchedEffect(createdPickId) {
+        createdPickId?.let {
+            onCreateClick(it)
+        }
+    }
 
     val dynamicBackgroundColor = Color(song.bgColor)
     val dynamicOnBackgroundColor = if (dynamicBackgroundColor.luminance() >= 0.5f) Black else White
@@ -90,7 +99,7 @@ fun CreatePickScreen(
             onBackClick()
         },
         onCreateClick = {
-            createPickViewModel.createPick(onCreateClick)
+            createPickViewModel.onCreatePickClick()
         },
         onCommentChange = createPickViewModel::onCommentChange
     )

--- a/app/src/main/java/com/squirtles/musicroad/create/CreatePickScreen.kt
+++ b/app/src/main/java/com/squirtles/musicroad/create/CreatePickScreen.kt
@@ -133,8 +133,9 @@ fun CreatePickScreen(
                 .background(Black.copy(alpha = 0.5F))
                 .clickable( // 클릭 효과 제거 및 클릭 이벤트 무시
                     interactionSource = remember { MutableInteractionSource() },
-                    indication = null
-                ) { },
+                    indication = null,
+                    onClick = {}
+                ),
             contentAlignment = Alignment.Center
         ) {
             CircularProgressIndicator()

--- a/app/src/main/java/com/squirtles/musicroad/create/CreatePickScreen.kt
+++ b/app/src/main/java/com/squirtles/musicroad/create/CreatePickScreen.kt
@@ -3,7 +3,10 @@ package com.squirtles.musicroad.create
 import android.app.Activity
 import android.util.Log
 import android.util.Size
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -21,6 +24,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -31,9 +35,12 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -66,13 +73,8 @@ fun CreatePickScreen(
 ) {
     val song = createPickViewModel.selectedSong ?: DEFAULT_SONG
     val comment = createPickViewModel.comment.collectAsStateWithLifecycle()
-    val createdPickId by createPickViewModel.createdPickId.collectAsStateWithLifecycle()
-
-    LaunchedEffect(createdPickId) {
-        createdPickId?.let {
-            onCreateClick(it)
-        }
-    }
+    val uiState by createPickViewModel.createPickUiState.collectAsStateWithLifecycle()
+    var showCreateIndicator by rememberSaveable { mutableStateOf(false) }
 
     val dynamicBackgroundColor = Color(song.bgColor)
     val dynamicOnBackgroundColor = if (dynamicBackgroundColor.luminance() >= 0.5f) Black else White
@@ -89,20 +91,55 @@ fun CreatePickScreen(
 
     Log.d("CreatePickScreen", song.toString())
 
-    CreatePickDisplay(
-        song = song,
-        comment = comment.value,
-        dynamicBackgroundColor = dynamicBackgroundColor,
-        dynamicOnBackgroundColor = dynamicOnBackgroundColor,
-        onBackClick = {
-            createPickViewModel.resetComment()
-            onBackClick()
-        },
-        onCreateClick = {
-            createPickViewModel.onCreatePickClick()
-        },
-        onCommentChange = createPickViewModel::onCommentChange
-    )
+    // 생성 중 인디케이터가 표시되고 있을 때는 시스템의 뒤로 가기 버튼 클릭을 무시
+    BackHandler(enabled = showCreateIndicator) { }
+
+    when (uiState) {
+        CreateUiState.Default -> {
+            CreatePickDisplay(
+                song = song,
+                comment = comment.value,
+                dynamicBackgroundColor = dynamicBackgroundColor,
+                dynamicOnBackgroundColor = dynamicOnBackgroundColor,
+                onBackClick = {
+                    createPickViewModel.resetComment()
+                    onBackClick()
+                },
+                onCreateClick = {
+                    createPickViewModel.onCreatePickClick()
+                    showCreateIndicator = true
+                },
+                onCommentChange = createPickViewModel::onCommentChange
+            )
+        }
+
+        is CreateUiState.Success -> {
+            showCreateIndicator = false
+            val pickId = (uiState as CreateUiState.Success<String>).data
+            onCreateClick(pickId)
+        }
+
+        CreateUiState.Error -> {
+            // TODO()
+            showCreateIndicator = false
+            Text("생성 오류")
+        }
+    }
+
+    if (showCreateIndicator) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Black.copy(alpha = 0.5F))
+                .clickable( // 클릭 효과 제거 및 클릭 이벤트 무시
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = null
+                ) { },
+            contentAlignment = Alignment.Center
+        ) {
+            CircularProgressIndicator()
+        }
+    }
 }
 
 @Composable

--- a/app/src/main/java/com/squirtles/musicroad/create/CreatePickUiState.kt
+++ b/app/src/main/java/com/squirtles/musicroad/create/CreatePickUiState.kt
@@ -1,0 +1,14 @@
+package com.squirtles.musicroad.create
+
+sealed class SearchUiState<out T> {
+    data object Init : SearchUiState<Nothing>()
+    data class Loading<T>(val prevData: T?) : SearchUiState<T>()
+    data class Success<T>(val data: T) : SearchUiState<T>()
+    data object Error : SearchUiState<Nothing>()
+}
+
+sealed class CreateUiState<out T> {
+    data object Default: CreateUiState<Nothing>()
+    data class Success<T>(val data: T) : CreateUiState<T>()
+    data object Error : CreateUiState<Nothing>()
+}

--- a/app/src/main/java/com/squirtles/musicroad/create/CreatePickViewModel.kt
+++ b/app/src/main/java/com/squirtles/musicroad/create/CreatePickViewModel.kt
@@ -13,7 +13,6 @@ import com.squirtles.domain.usecase.FetchLastLocationUseCase
 import com.squirtles.domain.usecase.GetCurrentUserUseCase
 import com.squirtles.domain.usecase.GetMusicVideoUrlUseCase
 import com.squirtles.domain.usecase.SearchSongsUseCase
-import com.squirtles.musicroad.UiState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
@@ -37,7 +36,7 @@ class CreatePickViewModel @Inject constructor(
 ) : ViewModel() {
 
     // SearchMusicScreen
-    private val _searchUiState = MutableStateFlow<UiState<List<Song>>>(UiState.Init)
+    private val _searchUiState = MutableStateFlow<SearchUiState<List<Song>>>(SearchUiState.Init)
     val searchUiState = _searchUiState.asStateFlow()
 
     private var _selectedSong: Song? = null
@@ -50,14 +49,14 @@ class CreatePickViewModel @Inject constructor(
     private var searchJob: Job? = null
 
     // CreatePickScreen
+    private val _createPickUiState = MutableStateFlow<CreateUiState<String>>(CreateUiState.Default)
+    val createPickUiState = _createPickUiState.asStateFlow()
+
     private val _comment = MutableStateFlow("")
     val comment get() = _comment
 
     private var lastLocation: Location? = null
     private val createPickClick = MutableSharedFlow<Unit>()
-
-    private val _createdPickId = MutableStateFlow<String?>(null)
-    val createdPickId = _createdPickId.asStateFlow()
 
     init {
         // 데이터소스의 위치값을 계속 collect하며 curLocation 변수에 저장
@@ -74,13 +73,14 @@ class CreatePickViewModel @Inject constructor(
                     searchJob?.cancel()
                     if (searchKeyword.isBlank()) {
                         searchResult = null
-                        _searchUiState.value = UiState.Init
+                        _searchUiState.value = SearchUiState.Init
                     } else {
                         searchJob = launch { searchSongs(searchKeyword) }
                     }
                 }
         }
 
+        // 등록 버튼 클릭 후 2초 이내의 클릭은 무시하고 픽 생성하기
         viewModelScope.launch {
             createPickClick
                 .throttleFirst(2000)
@@ -91,15 +91,15 @@ class CreatePickViewModel @Inject constructor(
     }
 
     private suspend fun searchSongs(searchKeyword: String) {
-        _searchUiState.value = UiState.Loading(searchResult)
+        _searchUiState.value = SearchUiState.Loading(searchResult)
         val result = searchSongsUseCase(searchKeyword)
 
         result.onSuccess {
             searchResult = it
-            _searchUiState.value = UiState.Success(it)
+            _searchUiState.value = SearchUiState.Success(it)
         }.onFailure {
             searchResult = null
-            _searchUiState.value = UiState.Error // NotFoundException(message=No such resource)
+            _searchUiState.value = SearchUiState.Error // NotFoundException(message=No such resource)
         }
     }
 
@@ -153,9 +153,10 @@ class CreatePickViewModel @Inject constructor(
                 )
 
                 createResult.onSuccess { pickId ->
-                    _createdPickId.emit(pickId)
+                    _createPickUiState.emit(CreateUiState.Success(pickId))
                 }.onFailure {
                     /* TODO: Firestore 등록 실패처리 */
+                    _createPickUiState.emit(CreateUiState.Error)
                     Log.d("CreatePickViewModel", createResult.exceptionOrNull()?.message.toString())
                 }
             }

--- a/app/src/main/java/com/squirtles/musicroad/create/CreatePickViewModel.kt
+++ b/app/src/main/java/com/squirtles/musicroad/create/CreatePickViewModel.kt
@@ -80,10 +80,10 @@ class CreatePickViewModel @Inject constructor(
                 }
         }
 
-        // 등록 버튼 클릭 후 2초 이내의 클릭은 무시하고 픽 생성하기
+        // 등록 버튼 클릭 후 3초 이내의 클릭은 무시하고 픽 생성하기
         viewModelScope.launch {
             createPickClick
-                .throttleFirst(2000)
+                .throttleFirst(3000)
                 .collect {
                     createPick()
                 }

--- a/app/src/main/java/com/squirtles/musicroad/create/SearchMusicScreen.kt
+++ b/app/src/main/java/com/squirtles/musicroad/create/SearchMusicScreen.kt
@@ -55,7 +55,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.squirtles.domain.model.Song
-import com.squirtles.musicroad.UiState
 import com.squirtles.musicroad.common.AlbumImage
 import com.squirtles.musicroad.ui.theme.Black
 import com.squirtles.musicroad.ui.theme.Gray
@@ -100,18 +99,18 @@ fun SearchMusicScreen(
                 .addFocusCleaner(focusManager)
         ) {
             when (uiState) {
-                UiState.Init -> {
+                SearchUiState.Init -> {
                     // TODO: HOT 리스트
                 }
 
-                is UiState.Loading -> {
+                is SearchUiState.Loading -> {
                     LinearProgressIndicator(
                         modifier = Modifier
                             .fillMaxWidth()
                             .padding(top = 10.dp),
                         trackColor = Gray
                     )
-                    (uiState as UiState.Loading).prevData?.let {
+                    (uiState as SearchUiState.Loading).prevData?.let {
                         SearchResult(
                             searchResult = it,
                             onItemClick = { song ->
@@ -122,9 +121,9 @@ fun SearchMusicScreen(
                     }
                 }
 
-                is UiState.Success -> {
+                is SearchUiState.Success -> {
                     SearchResult(
-                        searchResult = (uiState as UiState.Success).data,
+                        searchResult = (uiState as SearchUiState.Success).data,
                         onItemClick = { song ->
                             createPickViewModel.onSongItemClick(song)
                             onItemClick()
@@ -132,7 +131,7 @@ fun SearchMusicScreen(
                     )
                 }
 
-                UiState.Error -> {
+                SearchUiState.Error -> {
                     // TODO: 검색 결과가 없는 경우. 일단은 텍스트로만 처리해뒀습니다.
                     Text("검색 결과가 없습니다.", color = White)
                 }

--- a/app/src/main/java/com/squirtles/musicroad/main/navigations/MainNavGraph.kt
+++ b/app/src/main/java/com/squirtles/musicroad/main/navigations/MainNavGraph.kt
@@ -95,6 +95,7 @@ fun MainNavGraph(
             DetailPickScreen(
                 pickId = pickId,
                 onBackClick = { navController.navigateUp() },
+                onDeleted = { mapViewModel.resetClickedMarkerState(it) },
             )
         }
     }

--- a/app/src/main/java/com/squirtles/musicroad/map/components/ClusterBottomSheet.kt
+++ b/app/src/main/java/com/squirtles/musicroad/map/components/ClusterBottomSheet.kt
@@ -31,6 +31,8 @@ import com.squirtles.domain.model.LocationPoint
 import com.squirtles.domain.model.Pick
 import com.squirtles.domain.model.Song
 import com.squirtles.musicroad.common.AlbumImage
+import com.squirtles.musicroad.common.CreatedByOtherUserText
+import com.squirtles.musicroad.common.CreatedBySelfText
 import com.squirtles.musicroad.create.HorizontalSpacer
 import kotlinx.coroutines.launch
 

--- a/app/src/main/java/com/squirtles/musicroad/map/components/InfoWindowCard.kt
+++ b/app/src/main/java/com/squirtles/musicroad/map/components/InfoWindowCard.kt
@@ -31,6 +31,8 @@ import com.squirtles.domain.model.LocationPoint
 import com.squirtles.domain.model.Pick
 import com.squirtles.domain.model.Song
 import com.squirtles.musicroad.common.AlbumImage
+import com.squirtles.musicroad.common.CreatedByOtherUserText
+import com.squirtles.musicroad.common.CreatedBySelfText
 import com.squirtles.musicroad.ui.theme.Gray
 import com.squirtles.musicroad.ui.theme.MusicRoadTheme
 

--- a/app/src/main/java/com/squirtles/musicroad/map/components/Text.kt
+++ b/app/src/main/java/com/squirtles/musicroad/map/components/Text.kt
@@ -4,7 +4,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -23,45 +22,6 @@ fun SongInfoText(
         overflow = TextOverflow.Ellipsis,
         maxLines = 1,
         style = MaterialTheme.typography.titleMedium,
-    )
-}
-
-@Composable
-fun CreatedBySelfText(
-    modifier: Modifier = Modifier,
-    color: Color = MaterialTheme.colorScheme.onSurface,
-    style: TextStyle = MaterialTheme.typography.bodyMedium
-) {
-    Text(
-        text = stringResource(R.string.map_pick_created_by_self),
-        modifier = modifier,
-        color = color,
-        overflow = TextOverflow.Ellipsis,
-        maxLines = 1,
-        style = style,
-    )
-}
-
-@Composable
-fun CreatedByOtherUserText(
-    userName: String,
-    modifier: Modifier = Modifier,
-    color: Color = MaterialTheme.colorScheme.onSurface,
-    style: TextStyle = MaterialTheme.typography.bodyMedium
-) {
-    Text(
-        text = userName,
-        modifier = modifier,
-        color = color,
-        overflow = TextOverflow.Ellipsis,
-        maxLines = 1,
-        style = style,
-    )
-
-    Text(
-        text = stringResource(id = R.string.map_info_window_pick_user),
-        color = color,
-        style = style,
     )
 }
 

--- a/app/src/main/java/com/squirtles/musicroad/pick/DetailPickScreen.kt
+++ b/app/src/main/java/com/squirtles/musicroad/pick/DetailPickScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -60,6 +61,7 @@ import com.squirtles.musicroad.R
 import com.squirtles.musicroad.musicplayer.PlayerViewModel
 import com.squirtles.musicroad.pick.PickViewModel.Companion.DEFAULT_PICK
 import com.squirtles.musicroad.pick.components.CommentText
+import com.squirtles.musicroad.pick.components.DeletePickDialog
 import com.squirtles.musicroad.pick.components.DetailPickTopAppBar
 import com.squirtles.musicroad.pick.components.PickInformation
 import com.squirtles.musicroad.pick.components.SongInfo
@@ -96,6 +98,7 @@ fun DetailPickScreen(
     val uiState by pickViewModel.detailPickUiState.collectAsStateWithLifecycle()
     var isMusicVideoAvailable by remember { mutableStateOf(false) }
     var showMusicVideo by remember { mutableStateOf(false) }
+    var showDeletePickDialog by rememberSaveable { mutableStateOf(false) }
 
     LaunchedEffect(Unit) {
         pickViewModel.fetchPick(pickId)
@@ -127,7 +130,10 @@ fun DetailPickScreen(
                     swipeableModifier = swipeableModifier,
                     playerViewModel = playerViewModel,
                     onBackClick = onBackClick,
-                    onActionClick = { pickViewModel.deletePick(pickId) }
+                    onActionClick = {
+                        playerViewModel.pause()
+                        showDeletePickDialog = true
+                    }
                 )
 
                 // 최초 Swipe 동작 전에 MusicVideoScreen이 생성되지 않도록 함
@@ -171,7 +177,18 @@ fun DetailPickScreen(
         DetailPickUiState.Error -> {
             // TODO: pick 로딩 실패
         }
+    }
 
+    if (showDeletePickDialog) {
+        DeletePickDialog(
+            onDismissRequest = {
+                showDeletePickDialog = false
+            },
+            onDeletion = {
+                showDeletePickDialog = false
+                pickViewModel.deletePick(pickId)
+            }
+        )
     }
 }
 

--- a/app/src/main/java/com/squirtles/musicroad/pick/DetailPickScreen.kt
+++ b/app/src/main/java/com/squirtles/musicroad/pick/DetailPickScreen.kt
@@ -120,20 +120,35 @@ fun DetailPickScreen(
             val pick = (uiState as DetailPickUiState.Success).pick
             isMusicVideoAvailable = pick.musicVideoUrl.isNotEmpty()
 
+            val isCreatedBySelf = pickViewModel.getUserId() == pick.createdBy.userId
+            val onActionClick: () -> Unit = {
+                when {
+                    isCreatedBySelf -> {
+                        playerViewModel.pause()
+                        showDeletePickDialog = true
+                    }
+
+                    isFavorite -> {
+                        // TODO: 픽 담기 해제
+                    }
+
+                    else -> {
+                        // TODO: 픽 담기
+                    }
+                }
+            }
+
             Box(modifier = Modifier.fillMaxSize()) {
                 DetailPick(
                     pick = pick,
-                    isCreatedBySelf = pickViewModel.getUserId() == pick.createdBy.userId,
+                    isCreatedBySelf = isCreatedBySelf,
                     isFavorite = isFavorite, // TODO
                     userName = pick.createdBy.userName,
                     isMusicVideoAvailable = isMusicVideoAvailable,
                     swipeableModifier = swipeableModifier,
                     playerViewModel = playerViewModel,
                     onBackClick = onBackClick,
-                    onActionClick = {
-                        playerViewModel.pause()
-                        showDeletePickDialog = true
-                    }
+                    onActionClick = onActionClick
                 )
 
                 // 최초 Swipe 동작 전에 MusicVideoScreen이 생성되지 않도록 함

--- a/app/src/main/java/com/squirtles/musicroad/pick/DetailPickUiState.kt
+++ b/app/src/main/java/com/squirtles/musicroad/pick/DetailPickUiState.kt
@@ -1,0 +1,10 @@
+package com.squirtles.musicroad.pick
+
+import com.squirtles.domain.model.Pick
+
+sealed class DetailPickUiState {
+    data object Loading : DetailPickUiState()
+    data class Success(val pick: Pick) : DetailPickUiState()
+    data object Deleted : DetailPickUiState()
+    data object Error : DetailPickUiState()
+}

--- a/app/src/main/java/com/squirtles/musicroad/pick/PickViewModel.kt
+++ b/app/src/main/java/com/squirtles/musicroad/pick/PickViewModel.kt
@@ -7,8 +7,9 @@ import com.squirtles.domain.model.Creator
 import com.squirtles.domain.model.LocationPoint
 import com.squirtles.domain.model.Pick
 import com.squirtles.domain.model.Song
-import com.squirtles.domain.model.User
+import com.squirtles.domain.usecase.DeletePickUseCase
 import com.squirtles.domain.usecase.FetchPickUseCase
+import com.squirtles.domain.usecase.GetCurrentUserUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -17,17 +18,39 @@ import javax.inject.Inject
 
 @HiltViewModel
 class PickViewModel @Inject constructor(
-    private val fetchPickUseCase: FetchPickUseCase
+    private val fetchPickUseCase: FetchPickUseCase,
+    private val getCurrentUserUseCase: GetCurrentUserUseCase,
+    private val deletePickUseCase: DeletePickUseCase
 ) : ViewModel() {
 
-    private val _pick = MutableStateFlow(DEFAULT_PICK)
-    val pick = _pick.asStateFlow()
+    private val _detailPickUiState = MutableStateFlow<DetailPickUiState>(DetailPickUiState.Loading)
+    val detailPickUiState = _detailPickUiState.asStateFlow()
+
+    fun getUserId() = getCurrentUserUseCase().userId
 
     fun fetchPick(pickId: String) {
         viewModelScope.launch {
+            _detailPickUiState.emit(DetailPickUiState.Loading)
             fetchPickUseCase(pickId)
-                .onSuccess { _pick.emit(it) }
-                .onFailure { _pick.emit(DEFAULT_PICK) }
+                .onSuccess {
+                    _detailPickUiState.emit(DetailPickUiState.Success(it))
+                }
+                .onFailure {
+                    _detailPickUiState.emit(DetailPickUiState.Error)
+                }
+        }
+    }
+
+    fun deletePick(pickId: String) {
+        viewModelScope.launch {
+            _detailPickUiState.emit(DetailPickUiState.Loading)
+            deletePickUseCase(pickId)
+                .onSuccess {
+                    _detailPickUiState.emit(DetailPickUiState.Deleted)
+                }
+                .onFailure {
+                    _detailPickUiState.emit(DetailPickUiState.Error)
+                }
         }
     }
 

--- a/app/src/main/java/com/squirtles/musicroad/pick/components/DeletePickDialog.kt
+++ b/app/src/main/java/com/squirtles/musicroad/pick/components/DeletePickDialog.kt
@@ -1,0 +1,111 @@
+package com.squirtles.musicroad.pick.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.BasicAlertDialog
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.squirtles.musicroad.R
+import com.squirtles.musicroad.create.HorizontalSpacer
+import com.squirtles.musicroad.create.VerticalSpacer
+import com.squirtles.musicroad.ui.theme.Black
+import com.squirtles.musicroad.ui.theme.MusicRoadTheme
+import com.squirtles.musicroad.ui.theme.Primary
+import com.squirtles.musicroad.ui.theme.White
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DeletePickDialog(
+    onDismissRequest: () -> Unit,
+    onDeletion: () -> Unit
+) {
+    BasicAlertDialog(
+        onDismissRequest = { onDismissRequest() },
+    ) {
+        Surface(
+            modifier = Modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(16.dp),
+            color = White
+        ) {
+            Column(
+                modifier = Modifier.padding(24.dp),
+                verticalArrangement = Arrangement.Center
+            ) {
+                Text(
+                    text = stringResource(R.string.delete_pick_dialog_title),
+                    color = Black,
+                    fontWeight = FontWeight.Bold,
+                    style = MaterialTheme.typography.bodyLarge
+                )
+
+                VerticalSpacer(8)
+
+                Text(
+                    text = stringResource(R.string.delete_pick_dialog_body),
+                    color = Black,
+                    style = MaterialTheme.typography.bodyLarge
+                )
+
+                VerticalSpacer(24)
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.End,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    TextButton(
+                        onClick = { onDismissRequest() },
+                        colors = ButtonDefaults.buttonColors().copy(
+                            containerColor = Color.Transparent,
+                            contentColor = Black
+                        )
+                    ) {
+                        Text(stringResource(R.string.delete_pick_dialog_cancel))
+                    }
+
+                    HorizontalSpacer(8)
+
+                    TextButton(
+                        onClick = { onDeletion() },
+                        colors = ButtonDefaults.buttonColors().copy(
+                            containerColor = Color.Transparent,
+                            contentColor = Primary
+                        )
+                    ) {
+                        Text(
+                            text = stringResource(R.string.delete_pick_dialog_delete),
+                            fontWeight = FontWeight.Bold
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun DeletePickDialogPreview() {
+    MusicRoadTheme {
+        DeletePickDialog(
+            onDismissRequest = {},
+            onDeletion = {}
+        )
+    }
+}

--- a/app/src/main/java/com/squirtles/musicroad/pick/components/DetailPickTopAppBar.kt
+++ b/app/src/main/java/com/squirtles/musicroad/pick/components/DetailPickTopAppBar.kt
@@ -17,8 +17,8 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import com.squirtles.musicroad.R
-import com.squirtles.musicroad.map.components.CreatedByOtherUserText
-import com.squirtles.musicroad.map.components.CreatedBySelfText
+import com.squirtles.musicroad.common.CreatedByOtherUserText
+import com.squirtles.musicroad.common.CreatedBySelfText
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable

--- a/app/src/main/java/com/squirtles/musicroad/pick/components/DetailPickTopAppBar.kt
+++ b/app/src/main/java/com/squirtles/musicroad/pick/components/DetailPickTopAppBar.kt
@@ -1,0 +1,92 @@
+package com.squirtles.musicroad.pick.components
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import com.squirtles.musicroad.R
+import com.squirtles.musicroad.map.components.CreatedByOtherUserText
+import com.squirtles.musicroad.map.components.CreatedBySelfText
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DetailPickTopAppBar(
+    modifier: Modifier = Modifier,
+    isCreatedBySelf: Boolean,
+    isFavorite: Boolean,
+    userName: String,
+    onDynamicBackgroundColor: Color,
+    onBackClick: () -> Unit,
+    onActionClick: () -> Unit,
+) {
+    CenterAlignedTopAppBar(
+        title = {
+            Row(
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                if (isCreatedBySelf) {
+                    CreatedBySelfText(
+                        color = onDynamicBackgroundColor,
+                        style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold)
+                    )
+                } else {
+                    CreatedByOtherUserText(
+                        userName = userName,
+                        modifier = Modifier.weight(weight = 1f, fill = false),
+                        color = onDynamicBackgroundColor,
+                        style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold)
+                    )
+                }
+            }
+        },
+        modifier = modifier,
+        navigationIcon = {
+            IconButton(
+                onClick = { onBackClick() }
+            ) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                    contentDescription = stringResource(id = R.string.pick_app_bar_back_description),
+                    tint = onDynamicBackgroundColor
+                )
+            }
+        },
+        actions = {
+            IconButton(
+                onClick = { onActionClick() }
+            ) {
+                val painterResourceId = when {
+                    isCreatedBySelf -> R.drawable.ic_delete
+                    isFavorite -> R.drawable.ic_favorite_true
+                    else -> R.drawable.ic_favorite_false
+                }
+                val stringResourceId = when {
+                    isCreatedBySelf -> R.string.pick_delete_icon_description
+                    isFavorite -> R.string.pick_favorite_true_icon_description
+                    else -> R.string.pick_favorite_false_icon_description
+                }
+
+                Icon(
+                    painter = painterResource(painterResourceId),
+                    contentDescription = stringResource(stringResourceId),
+                    tint = onDynamicBackgroundColor
+                )
+            }
+        },
+        colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
+            containerColor = Color.Transparent
+        )
+    )
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -33,6 +33,7 @@
     <string name="player_forward_description">5초 앞으로</string>
     <string name="player_replay_description">5초 뒤로</string>
     <string name="player_play_pause_description">재생/일시정지</string>
+    <string name="success_delete_pick">삭제되었습니다</string>
 
     <!-- Search Music -->
     <string name="search_music_album_description">노래 앨범 이미지</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -38,4 +38,10 @@
     <!-- Search Music -->
     <string name="search_music_album_description">노래 앨범 이미지</string>
     <string name="search_music_search_button_description">노래 검색 버튼</string>
+
+    <!-- Delete Pick Dialog -->
+    <string name="delete_pick_dialog_title">삭제하시겠습니까?</string>
+    <string name="delete_pick_dialog_body">등록하신 픽이 삭제됩니다.</string>
+    <string name="delete_pick_dialog_cancel">취소</string>
+    <string name="delete_pick_dialog_delete">삭제하기</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,7 +16,7 @@
     <string name="map_album_image_description">앨범 이미지</string>
     <string name="map_info_window_pick_user">님의 픽</string>
     <string name="map_info_window_favorite_count_icon_description">픽을 담은 개수</string>
-    <string name="map_pick_created_by_self">내가 등록한 픽</string>
+    <string name="pick_created_by_self">내가 등록한 픽</string>
 
     <!-- Pick -->
     <string name="pick_app_bar_title">픽 등록</string>

--- a/data/src/main/java/com/squirtles/data/datasource/remote/applemusic/AppleMusicDataSourceImpl.kt
+++ b/data/src/main/java/com/squirtles/data/datasource/remote/applemusic/AppleMusicDataSourceImpl.kt
@@ -37,7 +37,7 @@ class AppleMusicDataSourceImpl @Inject constructor(
 
     private suspend fun requestSearchApi(searchText: String, types: String): SearchResponse {
         val queryMap = mapOf(
-            "term" to searchText.replace(" ", "+"),
+            "term" to searchText,
             "limit" to "10",
             "offset" to "0"
         )

--- a/data/src/main/java/com/squirtles/data/datasource/remote/firebase/FirebaseDataSourceImpl.kt
+++ b/data/src/main/java/com/squirtles/data/datasource/remote/firebase/FirebaseDataSourceImpl.kt
@@ -188,8 +188,21 @@ class FirebaseDataSourceImpl @Inject constructor(
                 }
         }
 
-    override suspend fun deletePick(pick: Pick): Boolean {
-        TODO("Not yet implemented")
+    override suspend fun deletePick(pickId: String): Boolean {
+        return suspendCancellableCoroutine { continuation ->
+            db.collection("picks").document(pickId)
+                .delete()
+                .addOnSuccessListener {
+                    Log.d("FirebaseDataSourceImpl", "삭제 성공")
+                    continuation.resume(true)
+                }
+                .addOnFailureListener { exception ->
+                    Log.e("FirebaseDataSourceImpl", "픽 삭제 실패 $exception")
+                    continuation.resumeWithException(exception)
+                }
+        }
+        // TODO: 유저가 등록한 리스트에서 이 픽 id를 삭제
+        // TODO: favorite에서 이 픽 id 삭제
     }
 
     private fun updateCurrentUserPick(userId: String, pickId: String): Task<Void> {

--- a/data/src/main/java/com/squirtles/data/datasource/remote/firebase/FirebaseDataSourceImpl.kt
+++ b/data/src/main/java/com/squirtles/data/datasource/remote/firebase/FirebaseDataSourceImpl.kt
@@ -39,7 +39,9 @@ class FirebaseDataSourceImpl @Inject constructor(
                     documentReference.get()
                         .addOnSuccessListener { documentSnapshot ->
                             val savedUser = documentSnapshot.toObject<FirebaseUser>()
-                            continuation.resume(savedUser?.toUser()?.copy(userId = documentReference.id))
+                            continuation.resume(
+                                savedUser?.toUser()?.copy(userId = documentReference.id)
+                            )
                         }
                         .addOnFailureListener { exception ->
                             continuation.resumeWithException(exception)

--- a/data/src/main/java/com/squirtles/data/repository/FirebaseRepositoryImpl.kt
+++ b/data/src/main/java/com/squirtles/data/repository/FirebaseRepositoryImpl.kt
@@ -48,8 +48,10 @@ class FirebaseRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun deletePick(pick: Pick): Result<Boolean> {
-        TODO("Not yet implemented")
+    override suspend fun deletePick(pickId: String): Result<Boolean> {
+        return handleResult {
+            firebaseRemoteDataSource.deletePick(pickId)
+        }
     }
 
     private suspend fun <T> handleResult(

--- a/domain/src/main/java/com/squirtles/domain/datasource/FirebaseRemoteDataSource.kt
+++ b/domain/src/main/java/com/squirtles/domain/datasource/FirebaseRemoteDataSource.kt
@@ -10,6 +10,6 @@ interface FirebaseRemoteDataSource {
     suspend fun fetchPick(pickID: String): Pick?
     suspend fun fetchPicksInArea(lat: Double, lng: Double, radiusInM: Double): List<Pick>
     suspend fun createPick(pick: Pick): String
-    suspend fun deletePick(pick: Pick): Boolean
+    suspend fun deletePick(pickId: String): Boolean
 //    suspend fun updatePick(pick: Pick)
 }

--- a/domain/src/main/java/com/squirtles/domain/repository/FirebaseRepository.kt
+++ b/domain/src/main/java/com/squirtles/domain/repository/FirebaseRepository.kt
@@ -6,8 +6,9 @@ import com.squirtles.domain.model.User
 interface FirebaseRepository {
     suspend fun createUser(): Result<User>
     suspend fun fetchUser(userId: String): Result<User>
+
     suspend fun fetchPick(pickID: String): Result<Pick>
     suspend fun fetchPicksInArea(lat: Double, lng: Double, radiusInM: Double): Result<List<Pick>>
     suspend fun createPick(pick: Pick): Result<String>
-    suspend fun deletePick(pick: Pick): Result<Boolean>
+    suspend fun deletePick(pickId: String): Result<Boolean>
 }

--- a/domain/src/main/java/com/squirtles/domain/usecase/DeletePickUseCase.kt
+++ b/domain/src/main/java/com/squirtles/domain/usecase/DeletePickUseCase.kt
@@ -1,0 +1,10 @@
+package com.squirtles.domain.usecase
+
+import com.squirtles.domain.repository.FirebaseRepository
+import javax.inject.Inject
+
+class DeletePickUseCase @Inject constructor(
+    private val firebaseRepository: FirebaseRepository
+) {
+    suspend operator fun invoke(pickId: String): Result<Boolean> = firebaseRepository.deletePick(pickId)
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
- resolved #22 

## 📝작업 내용 및 코드
- 내가 등록한 픽일 경우 삭제 버튼(휴지통 아이콘)을 눌렀을 때 삭제
- 픽 등록을 연속적으로 클릭했을 때 한 개만 등록될 수 있도록 설정 - ThrottleFirst
- 픽 등록 및 상세 화면 UiState 적용
  - 픽을 등록 중일 때 원형 인디케이터 보여지도록 하고 이때 배경 터치 및 뒤로 가기 버튼 무시
  - 상세 화면에서 삭제 버튼 누르면 다이얼로그로 묻고 삭제 시 지도로 돌아가기

https://github.com/user-attachments/assets/5c7257e2-ac22-49d2-946c-85aa4c75f978

[작업 과정 상세 내용](https://vaulted-system-3ae.notion.site/14cf85098cd580a7bce7c9c4b757ebed)

## 💬리뷰 요구사항
- throttleFirst의 시간을 2초로 해뒀는데 2초가 적당한지 여쭤봅니다! 제가 등록 요청 시 걸리는 시간을 확인했을 때 약 1초~1.5 이내인 것 같아서 2초로 설정했는데 더 늘리는 게 나을까요?

  ![image5](https://github.com/user-attachments/assets/7092e47c-1f43-45fa-85b3-b8122fac1934)
