### PR TITLE
[hotfix] 비주얼라이저 캡처 버그 해결 

### DIFF
--- a/app/src/main/java/com/squirtles/musicroad/musicplayer/PlayerViewModel.kt
+++ b/app/src/main/java/com/squirtles/musicroad/musicplayer/PlayerViewModel.kt
@@ -25,8 +25,8 @@ class PlayerViewModel @Inject constructor() : ViewModel() {
 
     private var player: ExoPlayer? = null
 
-    private val _audioSessionId = MutableStateFlow(0)
-    val audioSessionId: StateFlow<Int> = _audioSessionId
+    private var _audioSessionId = 0
+    val audioSessionId get() = _audioSessionId
 
     private val _playerState = MutableStateFlow(PLAYER_STATE_INITIAL)
     val playerState: StateFlow<PlayerState> = _playerState
@@ -37,6 +37,7 @@ class PlayerViewModel @Inject constructor() : ViewModel() {
     private val _duration = MutableStateFlow(30_000L)
     val duration: StateFlow<Long> = _duration
 
+    @OptIn(UnstableApi::class)
     private fun initializePlayer(context: Context) {
         val exoPlayer = ExoPlayer.Builder(context).build().also {
             it.addListener(object : Player.Listener {
@@ -54,9 +55,9 @@ class PlayerViewModel @Inject constructor() : ViewModel() {
             it.volume = 0.8f
         }
         this.player = exoPlayer
+        _audioSessionId = exoPlayer.audioSessionId
     }
 
-    @OptIn(UnstableApi::class)
     fun readyPlayer(context: Context, sourceUrl: String) {
         if (player != null) return
 
@@ -74,8 +75,6 @@ class PlayerViewModel @Inject constructor() : ViewModel() {
 
             _duration.value =
                 if (it.duration == TIME_UNSET) 30_000L else it.duration
-
-            _audioSessionId.value = it.audioSessionId
 
             updatePlayerStatePeriodically(it)
         }

--- a/app/src/main/java/com/squirtles/musicroad/pick/DetailPickScreen.kt
+++ b/app/src/main/java/com/squirtles/musicroad/pick/DetailPickScreen.kt
@@ -296,8 +296,8 @@ private fun DetailPick(
                         song = pick.song,
                         playerState = playerState,
                         duration = duration,
-                        audioSessionId = { playerViewModel.audioSessionId },
                         audioEffectColor = audioEffectColor,
+                        audioSessionId = { playerViewModel.audioSessionId },
                         onSeekChanged = { timeMs ->
                             playerViewModel.playerSeekTo(timeMs)
                         },

--- a/app/src/main/java/com/squirtles/musicroad/pick/DetailPickScreen.kt
+++ b/app/src/main/java/com/squirtles/musicroad/pick/DetailPickScreen.kt
@@ -233,7 +233,6 @@ private fun DetailPick(
     )
 
     // PlayerViewModel Collect
-    val audioSessionId by playerViewModel.audioSessionId.collectAsStateWithLifecycle()
     val playerState by playerViewModel.playerState.collectAsStateWithLifecycle()
     val bufferPercentage by playerViewModel.bufferPercentage.collectAsStateWithLifecycle()
     val duration by playerViewModel.duration.collectAsStateWithLifecycle()
@@ -289,19 +288,21 @@ private fun DetailPick(
                     dynamicOnBackgroundColor = onDynamicBackgroundColor
                 )
 
-                CircleAlbumCover(
-                    modifier = Modifier
-                        .size(320.dp)
-                        .align(Alignment.CenterHorizontally),
-                    song = pick.song,
-                    playerState = playerState,
-                    duration = duration,
-                    audioSessionId = audioSessionId,
-                    audioEffectColor = audioEffectColor,
-                    onSeekChanged = { timeMs ->
-                        playerViewModel.playerSeekTo(timeMs)
-                    },
-                )
+                if(playerState.isReady){
+                    CircleAlbumCover(
+                        modifier = Modifier
+                            .size(320.dp)
+                            .align(Alignment.CenterHorizontally),
+                        song = pick.song,
+                        playerState = playerState,
+                        duration = duration,
+                        audioSessionId = { playerViewModel.audioSessionId },
+                        audioEffectColor = audioEffectColor,
+                        onSeekChanged = { timeMs ->
+                            playerViewModel.playerSeekTo(timeMs)
+                        },
+                    )
+                }
 
                 PickInformation(formattedDate = pick.createdAt, favoriteCount = pick.favoriteCount)
 

--- a/app/src/main/java/com/squirtles/musicroad/pick/components/CircleAlbumCover.kt
+++ b/app/src/main/java/com/squirtles/musicroad/pick/components/CircleAlbumCover.kt
@@ -27,8 +27,8 @@ internal fun CircleAlbumCover(
     song: Song,
     playerState: PlayerState,
     duration: Long,
-    audioSessionId: () -> Int,
     audioEffectColor: Color,
+    audioSessionId: () -> Int,
     onSeekChanged: (Long) -> Unit,
 ) {
     Box(

--- a/app/src/main/java/com/squirtles/musicroad/pick/components/CircleAlbumCover.kt
+++ b/app/src/main/java/com/squirtles/musicroad/pick/components/CircleAlbumCover.kt
@@ -23,13 +23,13 @@ import com.squirtles.musicroad.pick.components.music.visualizer.CircleVisualizer
 
 @Composable
 internal fun CircleAlbumCover(
-    modifier: Modifier = Modifier,
     song: Song,
     playerState: PlayerState,
     duration: Long,
-    audioSessionId: () -> Int,
     audioEffectColor: Color,
+    audioSessionId: () -> Int,
     onSeekChanged: (Long) -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     Box(
         modifier = modifier

--- a/app/src/main/java/com/squirtles/musicroad/pick/components/CircleAlbumCover.kt
+++ b/app/src/main/java/com/squirtles/musicroad/pick/components/CircleAlbumCover.kt
@@ -27,7 +27,7 @@ internal fun CircleAlbumCover(
     song: Song,
     playerState: PlayerState,
     duration: Long,
-    audioSessionId: Int,
+    audioSessionId: () -> Int,
     audioEffectColor: Color,
     onSeekChanged: (Long) -> Unit,
 ) {
@@ -35,7 +35,7 @@ internal fun CircleAlbumCover(
         modifier = modifier
     ) {
         CircleVisualizer(
-            audioSessionId = audioSessionId,
+            audioSessionId = audioSessionId(),
             color = audioEffectColor,
             sizeRatio = 0.5f,
             modifier = Modifier.align(Alignment.Center)


### PR DESCRIPTION
시각화 시 기기 모든 출력 오디오 캡처해서 시각화되던 문제 해결

## #️⃣연관된 이슈

> ex) #이슈번호

## 📝작업 내용 및 코드

오디오 시각화 시 기기 전체 오디오 캡처해서 사용하던 버그 수정

원인: Visualizer 생성자 audioSession에 0 들어가면 모든 오디오 캡처되는데
PlayerViewModel의 audioSession staetflow 초기값이 0이라서 발생하던 문제

## 💬리뷰 요구사항(선택)
