### PR TITLE
[refactor] 픽 보관함/등록한 픽 목록을 보여주는 순서 설정

### DIFF
--- a/app/src/main/java/com/squirtles/musicroad/common/PickInfoText.kt
+++ b/app/src/main/java/com/squirtles/musicroad/common/PickInfoText.kt
@@ -70,7 +70,7 @@ fun CommentText(
 
 @Composable
 fun TotalCountText(
-    modifier: Modifier,
+    modifier: Modifier = Modifier,
     totalCount: Int,
     defaultColor: Color = MaterialTheme.colorScheme.onSurface,
     pointColor: Color = MaterialTheme.colorScheme.primary,
@@ -80,7 +80,8 @@ fun TotalCountText(
         text = buildAnnotatedString {
             withStyle(
                 SpanStyle(
-                    color = defaultColor
+                    color = defaultColor,
+                    fontWeight = FontWeight.Bold
                 )
             ) {
                 append("전체 ")

--- a/app/src/main/java/com/squirtles/musicroad/picklist/PickItem.kt
+++ b/app/src/main/java/com/squirtles/musicroad/picklist/PickItem.kt
@@ -9,12 +9,15 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.squirtles.domain.model.Song
 import com.squirtles.musicroad.common.AlbumImage
@@ -34,6 +37,7 @@ internal fun PickItem(
     createUserName: String,
     favoriteCount: Int,
     comment: String,
+    createdAt: String,
     onItemClick: () -> Unit,
 ) {
     Row(
@@ -74,8 +78,18 @@ internal fun PickItem(
                         modifier = Modifier.weight(weight = 1f, fill = false),
                         color = Gray
                     )
-                    HorizontalSpacer(8)
+                } else {
+                    Text(
+                        text = createdAt,
+                        modifier = Modifier.weight(weight = 1f, fill = false),
+                        color = Gray,
+                        overflow = TextOverflow.Ellipsis,
+                        maxLines = 1,
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
                 }
+
+                HorizontalSpacer(8)
 
                 FavoriteCountText(
                     favoriteCount = favoriteCount,

--- a/app/src/main/java/com/squirtles/musicroad/picklist/PickListScreen.kt
+++ b/app/src/main/java/com/squirtles/musicroad/picklist/PickListScreen.kt
@@ -1,8 +1,10 @@
 package com.squirtles.musicroad.picklist
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -81,13 +83,26 @@ fun PickListScreen(
                     Column(
                         modifier = Modifier.fillMaxSize()
                     ) {
-                        TotalCountText(
+                        Row(
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .padding(horizontal = DEFAULT_PADDING),
-                            totalCount = pickList.size,
-                            defaultColor = White,
-                        )
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            TotalCountText(
+                                totalCount = pickList.size,
+                                defaultColor = White,
+                            )
+
+                            Text(
+                                text = stringResource(
+                                    if (isFavoritePicks) R.string.latest_favorite_order else R.string.latest_create_order
+                                ),
+                                color = White,
+                                style = MaterialTheme.typography.bodyMedium
+                            )
+                        }
 
                         VerticalSpacer(8)
 
@@ -118,6 +133,7 @@ fun PickListScreen(
                                         createUserName = pick.createdBy.userName,
                                         favoriteCount = pick.favoriteCount,
                                         comment = pick.comment,
+                                        createdAt = pick.createdAt,
                                         onItemClick = { onItemClick(pick.id) }
                                     )
                                 }

--- a/app/src/main/java/com/squirtles/musicroad/userinfo/UserInfoMenus.kt
+++ b/app/src/main/java/com/squirtles/musicroad/userinfo/UserInfoMenus.kt
@@ -95,6 +95,8 @@ internal fun UserInfoMenus(
                 )
             }
         }
+
+        VerticalSpacer(20)
     }
 }
 

--- a/app/src/main/java/com/squirtles/musicroad/userinfo/UserInfoScreen.kt
+++ b/app/src/main/java/com/squirtles/musicroad/userinfo/UserInfoScreen.kt
@@ -7,7 +7,9 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.MusicNote
 import androidx.compose.material.icons.outlined.Archive
@@ -34,6 +36,8 @@ fun UserInfoScreen(
     onFavoritePicksClick: () -> Unit,
     onMyPicksClick: () -> Unit,
 ) {
+    val scrollState = rememberScrollState()
+
     Scaffold(
         topBar = {
             DefaultTopAppBar(
@@ -49,6 +53,7 @@ fun UserInfoScreen(
                 .padding(innerPadding)
         ) {
             Column(
+                modifier = Modifier.verticalScroll(scrollState),
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
                 VerticalSpacer(16)
@@ -81,8 +86,6 @@ fun UserInfoScreen(
                         )
                     )
                 )
-
-                VerticalSpacer(20)
 
                 UserInfoMenus(
                     title = stringResource(R.string.user_info_setting_category_title),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -41,6 +41,8 @@
     <string name="favorite_picks_empty">담은 픽이 없습니다</string>
     <string name="my_picks_empty">등록한 픽이 없습니다</string>
     <string name="error_loading_pick_list">일시적인 오류가 발생했습니다.</string>
+    <string name="latest_create_order">최근 등록순</string>
+    <string name="latest_favorite_order">최근 담은순</string>
 
     <!-- Search Music -->
     <string name="search_music_album_description">노래 앨범 이미지</string>

--- a/data/src/main/java/com/squirtles/data/datasource/remote/firebase/FirebaseDataSourceImpl.kt
+++ b/data/src/main/java/com/squirtles/data/datasource/remote/firebase/FirebaseDataSourceImpl.kt
@@ -239,7 +239,7 @@ class FirebaseDataSourceImpl @Inject constructor(
             }
         }
 
-        return myPicks
+        return myPicks.reversed()
     }
 
     override suspend fun fetchFavoritePicks(userId: String): List<Pick> {
@@ -349,6 +349,7 @@ class FirebaseDataSourceImpl @Inject constructor(
         return suspendCancellableCoroutine { continuation ->
             db.collection(COLLECTION_FAVORITES)
                 .whereEqualTo(FIELD_USER_ID, userId)
+                .orderBy(FIELD_ADDED_AT, Query.Direction.DESCENDING)
                 .get()
                 .addOnSuccessListener { result ->
                     continuation.resume(result)
@@ -401,5 +402,6 @@ class FirebaseDataSourceImpl @Inject constructor(
 
         private const val FIELD_PICK_ID = "pickId"
         private const val FIELD_USER_ID = "userId"
+        private const val FIELD_ADDED_AT = "addedAt"
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- 없음

## 📝 작업 내용 및 코드
- 픽 보관함/등록한 픽 목록을 최근 담은순/최근 등록순으로 보여지도록 했습니다.

  |픽 보관함|등록한 픽|
  |:---:|:---:|
  |<img src="https://github.com/user-attachments/assets/7e64f0e9-4771-4b90-9d4b-ad5c4a30aa98" width="300">|<img src="https://github.com/user-attachments/assets/51c0df3a-88d5-4ef7-a5cf-4f5c91c6cdf0" width="300">|

### 픽 보관함
내 이름 맑음 → Zombie → Heart Shaker 순서로 픽을 담았다. 최근에 담은 순서대로 보여지게 하려면 Heart Shaker → Zombie → 내 이름 맑은 순서대로 보여져야 할 것이다. 현재 상태는 아래처럼 보여진다.

<img src="https://github.com/user-attachments/assets/a4be6755-be3b-428e-b1bd-10b0848391dd" width="300">

담은 픽을 가져올 때는 favorites에서 userId가 일치하는 문서들을 가져와서 이 문서들의 순서대로 안에 있는 pickId와 일치하는 픽 정보를 가져온다. 그 이유는 컬렉션에서 여러 문서를 가져올 때 쿼리를 만족하는 모든 문서를 **문서 ID에 따라 오름차순으로 검색**하기 때문이다.

<details>
<summary>favorites에서 가져온 문서들의 순서대로 픽을 가져오는 것이 보장되는 이유</summary>
    
```kotlin
try {
    favoriteDocuments.forEach { doc ->
        tasks.add(
            db.collection(COLLECTION_PICKS)
                .document(doc.data[FIELD_PICK_ID].toString())
                .get()
        )
    }
    Tasks.whenAllComplete(tasks).await()
} catch (exception: Exception) {
    Log.e("FirebaseDataSourceImpl", "Failed to get favorite picks", exception)
    throw exception
}
tasks.forEach { task ->
    task.result.toObject<FirebasePick>()?.run {
        favorites.add(this.toPick().copy(id = task.result.id))
    }
}

return favorites
```
    
tasks에 문서 순서대로 요청을 넣고 요청이 완료될 때까지 기다린 후에 완료된 요청 목록에서 순서대로 픽을 꺼내기 때문

</details>

![image (7)](https://github.com/user-attachments/assets/3be1749a-4548-4134-93a6-f33905527a36)

Firestore의 favorites에 위에서 담은 것들의 문서 id가 아래와 같다.

- 내 이름 맑음 : 9~
- Zombie : p~
- Heart Shaker : c~

따라서 문서 id 순서대로 내 이름 맑음 → Heart Shaker → Zombie가 목록에 보여지는 것이었다. 그럼 favorites에서 문서를 가져올 때 담은 시간이 저장된 필드인 `addedAt`을 내림차순으로 가져오면 해결될 것이다.

[Firestore 데이터 정렬](https://firebase.google.com/docs/firestore/query-data/order-limit-data?hl=ko)

`orderBy()`를 사용하면 정렬할 수 있다. 기본 orderBy는 오름차순이다.
시간을 최신 순으로 가져오기 위해 `Query.Direction.DESCENDING`을 사용했다.

```kotlin
db.collection(COLLECTION_FAVORITES)
      .whereEqualTo(FIELD_USER_ID, userId)
      .orderBy(FIELD_ADDED_AT, Query.Direction.DESCENDING)
      .get()
```

위처럼 단순히 favorites에서 userId가 일치하는 문서를 가져오는 곳에 orderBy를 추가하면 될 줄 알았다. 그런데 가져오는 과정에서 오류가 발생했다. 오류가 발생하면 Log.w()로 로그를 찍었기 때문에 Logcat에서 is:warn으로 필터링하여 로그를 보니 이런 게 있었다.

![image (8)](https://github.com/user-attachments/assets/88eed209-8d77-4b3a-8726-9d2cb3201f08)

이런 오류가 있고 뒤에 링크가 있었다. 들어가니 아래처럼 추가 색인 생성이 필요하다고 했다.

![image (11)](https://github.com/user-attachments/assets/887ae23c-3c8e-4f87-956f-64727d01d95f)

Cloud Firestore에서는 단일 필드 색인에서 아직 지원하지 않는 복합 쿼리에 복합 색인을 사용한다고 한다. __name__은 문서 ID 또는 문서 경로이며 각 항목이 고유한지 확인하기 위해 자동으로 추가되는 것이다. 또한 색인을 만들기 위해서는 __name__을 제외하고 두 개 이상의 필드가 필요하다.

![image (9)](https://github.com/user-attachments/assets/bbbfb431-aaa5-4266-9ffd-c50e296edb76)

이렇게 색인이 추가된 후에 다시 수행하니 원하는 대로 잘 되었다.

<img src="https://github.com/user-attachments/assets/b366da08-3934-46c6-a925-f9b264dfc483" width="300">

### 등록한 픽

등록한 픽은 users에서 해당 유저의 문서를 가져와서 myPicks 안에 있는 pickId 리스트 순서대로 픽 정보를 가져오는 요청을 tasks에 넣고 작업이 모두 완료되면 tasks에 있는 순서대로 픽 정보를 저장하여 리스트로 반환한다. 픽을 등록할 때 등록한 픽의 id는 myPicks 맨 뒤에 추가되기 때문에 언제나 가장 먼저 등록을 한 순서대로 등록한 픽 정보 리스트를 반환하고 있었다. 그래서 가장 최근에 등록한 순서대로 리스트를 반환하려면 단순히 역순으로 된 리스트를 반환하면 된다.

```kotlin
override suspend fun fetchMyPicks(userId: String): List<Pick> {
    val userDocument = fetchUserDocument(userId)
    if (userDocument.exists().not()) throw Exception("No user info in database")

    val tasks = mutableListOf<Task<DocumentSnapshot>>()
    val myPicks = mutableListOf<Pick>()

    try {
        userDocument.toObject<FirebaseUser>()?.myPicks?.forEach { pickId ->
            tasks.add(
                db.collection(COLLECTION_PICKS)
                    .document(pickId)
                    .get()
            )
        }
        Tasks.whenAllComplete(tasks).await()
    } catch (exception: Exception) {
        Log.e("FirebaseDataSourceImpl", "Failed to fetch my picks", exception)
        throw exception
    }

    tasks.forEach { task ->
        task.result.toObject<FirebasePick>()?.run {
            myPicks.add(this.toPick().copy(id = task.result.id))
        }
    }

    return myPicks.reversed() // 최근에 등록한 순으로 반환
}
```

정렬 기준이 생김에 따라 텍스트도 추가해줬다.
