### PR TITLE
[feature] 현재 위치 로딩 다이얼로그 및 권한 요청 방식 수정

### DIFF
--- a/app/src/main/java/com/squirtles/musicroad/main/MainActivity.kt
+++ b/app/src/main/java/com/squirtles/musicroad/main/MainActivity.kt
@@ -1,15 +1,22 @@
 package com.squirtles.musicroad.main
 
 import android.Manifest
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
+import android.provider.Settings
 import android.util.Log
 import android.widget.Toast
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.core.content.PermissionChecker
 import androidx.core.splashscreen.SplashScreen
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
@@ -30,18 +37,7 @@ import kotlinx.coroutines.withTimeout
 @AndroidEntryPoint
 class MainActivity : AppCompatActivity() {
     private val mainViewModel by viewModels<MainViewModel>()
-    private val permissionLauncher = registerForActivityResult(
-        ActivityResultContracts.RequestMultiplePermissions()
-    ) { permissions ->
-        val allPermissionsGranted = permissions.all { it.value }
-        if (!allPermissionsGranted) {
-            Toast.makeText(
-                this,
-                getString(R.string.main_permission_deny_message),
-                Toast.LENGTH_LONG
-            ).show()
-        }
-    }
+
 
     override fun onCreate(savedInstanceState: Bundle?) {
         val splashScreen = installSplashScreen()
@@ -49,21 +45,49 @@ class MainActivity : AppCompatActivity() {
 
         setKeepOnScreenCondition(splashScreen)
         enableEdgeToEdge()
-        setContent {
-            MusicRoadTheme {
-                val navController = rememberNavController()
-                val navigationActions = remember(navController) {
-                    MainNavigationActions(navController)
-                }
-                MainNavGraph(
-                    navController = navController,
-                    navigationActions = navigationActions
-                )
-            }
-        }
 
         if (!checkSelfPermission()) {
-            permissionLauncher.launch(PERMISSIONS)
+            requestPermissions(PERMISSIONS, REQUEST_PERMISSION_CODE)
+        } else {
+            setMusicRoad()
+        }
+    }
+
+    override fun onRequestPermissionsResult(
+        requestCode: Int,
+        permissions: Array<out String>,
+        grantResults: IntArray
+    ) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
+
+        val deniedPermission = permissions.filterIndexed { index, _ ->
+            grantResults[index] == -1
+        }
+
+        if (requestCode == REQUEST_PERMISSION_CODE) {
+            if (deniedPermission.isEmpty()) { // 모든 권한이 허용된 경우
+                setMusicRoad()
+            } else { // 권한이 하나라도 거부된 경우
+                if (shouldShowRequestPermissionRationale(deniedPermission[0])) { // 권한 요청 가능 시 재요청
+                    showNeedPermissionDialog(true) {
+                        showNeedPermissionDialog(false)
+                        requestPermissions(deniedPermission.toTypedArray(), REQUEST_PERMISSION_CODE)
+                    }
+                } else { // 권한 2번 거절 시
+                    mainViewModel.setCanRequestPermission(false)
+                    showPermissionSnackbar()
+                }
+            }
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+
+        if (checkSelfPermission()) {
+            setMusicRoad()
+        } else if (mainViewModel.canRequestPermission.not()) {
+            showPermissionSnackbar()
         }
     }
 
@@ -120,11 +144,66 @@ class MainActivity : AppCompatActivity() {
         Toast.makeText(this, message, Toast.LENGTH_LONG).show()
     }
 
+    private fun setMusicRoad() {
+        setContent {
+            MusicRoadTheme {
+                val navController = rememberNavController()
+                val navigationActions = remember(navController) {
+                    MainNavigationActions(navController)
+                }
+                MainNavGraph(
+                    navController = navController,
+                    navigationActions = navigationActions
+                )
+            }
+        }
+    }
+
+    private fun showNeedPermissionDialog(
+        showDialog: Boolean,
+        onConfirmClick: () -> Unit = {},
+    ) {
+        setContent {
+            MusicRoadTheme {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    NeedPermissionDialog(
+                        showDialog = showDialog,
+                        onConfirmClick = onConfirmClick
+                    )
+                }
+            }
+        }
+    }
+
+    private fun showPermissionSnackbar() {
+        setContent {
+            MusicRoadTheme {
+                PermissionSnackbar(
+                    onActionPerformed = {
+                        val intent =
+                            Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
+                        val uri = Uri.fromParts("package", packageName, null)
+                        intent.data = uri
+                        startActivity(intent)
+                    },
+                    onDismissed = {
+                        showToast(getString(R.string.main_need_permissions))
+                        finish()
+                    }
+                )
+            }
+        }
+    }
+
     companion object {
         private val PERMISSIONS = arrayOf(
             Manifest.permission.ACCESS_FINE_LOCATION,
             Manifest.permission.ACCESS_COARSE_LOCATION,
             Manifest.permission.RECORD_AUDIO
         )
+        private const val REQUEST_PERMISSION_CODE = 1000
     }
 }

--- a/app/src/main/java/com/squirtles/musicroad/main/MainActivity.kt
+++ b/app/src/main/java/com/squirtles/musicroad/main/MainActivity.kt
@@ -111,7 +111,8 @@ class MainActivity : AppCompatActivity() {
 
     private fun checkSelfPermission(): Boolean {
         return PERMISSIONS.all { permission ->
-            PermissionChecker.checkSelfPermission(this, permission) == PermissionChecker.PERMISSION_GRANTED
+            PermissionChecker.checkSelfPermission(this, permission) ==
+                    PermissionChecker.PERMISSION_GRANTED
         }
     }
 

--- a/app/src/main/java/com/squirtles/musicroad/main/MainActivity.kt
+++ b/app/src/main/java/com/squirtles/musicroad/main/MainActivity.kt
@@ -49,7 +49,7 @@ class MainActivity : AppCompatActivity() {
         if (!checkSelfPermission()) {
             requestPermissions(PERMISSIONS, REQUEST_PERMISSION_CODE)
         } else {
-            setMusicRoad()
+            setMusicRoadContent()
         }
     }
 
@@ -66,7 +66,7 @@ class MainActivity : AppCompatActivity() {
 
         if (requestCode == REQUEST_PERMISSION_CODE) {
             if (deniedPermission.isEmpty()) { // 모든 권한이 허용된 경우
-                setMusicRoad()
+                setMusicRoadContent()
             } else { // 권한이 하나라도 거부된 경우
                 if (shouldShowRequestPermissionRationale(deniedPermission[0])) { // 권한 요청 가능 시 재요청
                     showNeedPermissionDialog(true) {
@@ -85,7 +85,7 @@ class MainActivity : AppCompatActivity() {
         super.onResume()
 
         if (checkSelfPermission()) {
-            setMusicRoad()
+            setMusicRoadContent()
         } else if (mainViewModel.canRequestPermission.not()) {
             showPermissionSnackbar()
         }
@@ -144,7 +144,7 @@ class MainActivity : AppCompatActivity() {
         Toast.makeText(this, message, Toast.LENGTH_LONG).show()
     }
 
-    private fun setMusicRoad() {
+    private fun setMusicRoadContent() {
         setContent {
             MusicRoadTheme {
                 val navController = rememberNavController()

--- a/app/src/main/java/com/squirtles/musicroad/main/MainActivity.kt
+++ b/app/src/main/java/com/squirtles/musicroad/main/MainActivity.kt
@@ -85,27 +85,24 @@ class MainActivity : AppCompatActivity() {
                                 }
 
                                 is LoadingState.NetworkError -> {
-                                    Toast.makeText(this@MainActivity, getString(R.string.main_network_error_message), Toast.LENGTH_LONG)
-                                        .show()
+                                    showToast(getString(R.string.main_network_error_message))
                                     finish()
                                 }
 
                                 is LoadingState.UserNotFoundError -> {
-                                    Toast.makeText(this@MainActivity, getString(R.string.main_user_not_found_message), Toast.LENGTH_LONG)
-                                        .show()
+                                    showToast(getString(R.string.main_user_not_found_message))
                                     finish()
                                 }
 
                                 is LoadingState.CreatedUserError -> {
-                                    Toast.makeText(this@MainActivity, getString(R.string.main_create_user_fail_message), Toast.LENGTH_LONG)
-                                        .show()
+                                    showToast(getString(R.string.main_create_user_fail_message))
                                     finish()
                                 }
                             }
                         }
                     }
                 } catch (e: TimeoutCancellationException) {
-                    Toast.makeText(this@MainActivity, getString(R.string.main_network_error_message), Toast.LENGTH_LONG).show()
+                    showToast(getString(R.string.main_network_error_message))
                     finish()
                 }
             }
@@ -116,6 +113,10 @@ class MainActivity : AppCompatActivity() {
         return PERMISSIONS.all { permission ->
             PermissionChecker.checkSelfPermission(this, permission) == PermissionChecker.PERMISSION_GRANTED
         }
+    }
+
+    private fun Context.showToast(message: String) {
+        Toast.makeText(this, message, Toast.LENGTH_LONG).show()
     }
 
     companion object {

--- a/app/src/main/java/com/squirtles/musicroad/main/MainViewModel.kt
+++ b/app/src/main/java/com/squirtles/musicroad/main/MainViewModel.kt
@@ -30,6 +30,9 @@ class MainViewModel @Inject constructor(
     private val _loadingState = MutableStateFlow<LoadingState>(LoadingState.Loading)
     val loadingState = _loadingState.asStateFlow()
 
+    private var _canRequestPermission = true
+    val canRequestPermission get() = _canRequestPermission
+
     private val _localUserId = getUserIdFromLocalStorageUseCase()
 
     init {
@@ -42,6 +45,10 @@ class MainViewModel @Inject constructor(
                 }
             }
         }
+    }
+
+    fun setCanRequestPermission(canRequest: Boolean) {
+        _canRequestPermission = canRequest
     }
 
     private suspend fun createUser() {

--- a/app/src/main/java/com/squirtles/musicroad/main/NeedPermissionDialog.kt
+++ b/app/src/main/java/com/squirtles/musicroad/main/NeedPermissionDialog.kt
@@ -1,0 +1,96 @@
+package com.squirtles.musicroad.main
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.BasicAlertDialog
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.squirtles.musicroad.R
+import com.squirtles.musicroad.common.HorizontalSpacer
+import com.squirtles.musicroad.common.VerticalSpacer
+import com.squirtles.musicroad.ui.theme.Black
+import com.squirtles.musicroad.ui.theme.DarkGray
+import com.squirtles.musicroad.ui.theme.MusicRoadTheme
+import com.squirtles.musicroad.ui.theme.White
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun NeedPermissionDialog(
+    showDialog: Boolean,
+    onConfirmClick: () -> Unit,
+) {
+    if (showDialog) {
+        BasicAlertDialog(
+            onDismissRequest = {},
+        ) {
+            Surface(
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(16.dp),
+                color = White
+            ) {
+                Column(
+                    modifier = Modifier.padding(24.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.Center
+                ) {
+                    Text(
+                        text = stringResource(R.string.request_permissions_title),
+                        color = Black,
+                        fontWeight = FontWeight.Bold,
+                        style = MaterialTheme.typography.bodyLarge
+                    )
+
+                    VerticalSpacer(8)
+
+                    Text(
+                        text = stringResource(R.string.request_permissions_body),
+                        color = Black,
+                        textAlign = TextAlign.Center,
+                        style = MaterialTheme.typography.bodyLarge
+                    )
+
+                    VerticalSpacer(24)
+
+                    TextButton(
+                        onClick = onConfirmClick,
+                        colors = ButtonDefaults.buttonColors().copy(
+                            containerColor = Color.Transparent,
+                            contentColor = DarkGray
+                        )
+                    ) {
+                        Text(stringResource(R.string.confirm_text))
+                    }
+
+                    HorizontalSpacer(8)
+                }
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun NeedPermissionDialogPreview() {
+    MusicRoadTheme {
+        NeedPermissionDialog(
+            showDialog = true,
+            onConfirmClick = {},
+        )
+    }
+}

--- a/app/src/main/java/com/squirtles/musicroad/main/PermissionSnackbar.kt
+++ b/app/src/main/java/com/squirtles/musicroad/main/PermissionSnackbar.kt
@@ -1,0 +1,59 @@
+package com.squirtles.musicroad.main
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarResult
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import com.squirtles.musicroad.R
+
+@Composable
+fun PermissionSnackbar(
+    onActionPerformed: () -> Unit,
+    onDismissed: () -> Unit,
+) {
+    val context = LocalContext.current
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    LaunchedEffect(Unit) {
+        val result = snackbarHostState
+            .showSnackbar(
+                message = context.getString(R.string.snackbar_text),
+                actionLabel = context.getString(R.string.action_to_setting),
+                duration = SnackbarDuration.Indefinite
+            )
+
+        when (result) {
+            SnackbarResult.ActionPerformed -> {
+                onActionPerformed()
+            }
+
+            SnackbarResult.Dismissed -> {
+                onDismissed()
+            }
+        }
+    }
+
+    Scaffold(
+        snackbarHost = {
+            SnackbarHost(hostState = snackbarHostState)
+        }
+    ) { innerPadding ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(MaterialTheme.colorScheme.surface)
+                .padding(innerPadding)
+        )
+    }
+}

--- a/app/src/main/java/com/squirtles/musicroad/map/MapScreen.kt
+++ b/app/src/main/java/com/squirtles/musicroad/map/MapScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -24,9 +25,11 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.squirtles.musicroad.common.VerticalSpacer
+import com.squirtles.musicroad.main.MainActivity
 import com.squirtles.musicroad.map.components.BottomNavigation
 import com.squirtles.musicroad.map.components.ClusterBottomSheet
 import com.squirtles.musicroad.map.components.InfoWindow
+import com.squirtles.musicroad.map.components.LoadingDialog
 import com.squirtles.musicroad.map.components.PickNotificationBanner
 import com.squirtles.musicroad.musicplayer.PlayerViewModel
 
@@ -47,6 +50,7 @@ fun MapScreen(
 
     val context = LocalContext.current
     var showBottomSheet by remember { mutableStateOf(false) }
+    var showLocationLoading by rememberSaveable { mutableStateOf(true) }
     var isPlaying: Boolean by remember { mutableStateOf(false) }
 
     LaunchedEffect(nearPicks) {
@@ -57,6 +61,10 @@ fun MapScreen(
 
     LaunchedEffect(playerState) {
         isPlaying = playerState.isPlaying
+    }
+
+    LaunchedEffect(lastLocation) {
+        showLocationLoading = lastLocation == null
     }
 
     Scaffold(
@@ -161,6 +169,19 @@ fun MapScreen(
                         onPickSummaryClick(pickId)
                     }
                 )
+            }
+
+            if (showLocationLoading) {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    LoadingDialog(
+                        onCloseClick = {
+                            (context as MainActivity).finish()
+                        }
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/com/squirtles/musicroad/map/NaverMap.kt
+++ b/app/src/main/java/com/squirtles/musicroad/map/NaverMap.kt
@@ -139,7 +139,7 @@ fun NaverMap(
         modifier = Modifier.fillMaxSize()
     )
 
-    if(isSystemInDarkTheme()) {
+    if (isSystemInDarkTheme()) {
         naverMap.value?.isNightModeEnabled = true
     }
 }

--- a/app/src/main/java/com/squirtles/musicroad/map/components/LoadingDialog.kt
+++ b/app/src/main/java/com/squirtles/musicroad/map/components/LoadingDialog.kt
@@ -1,0 +1,87 @@
+package com.squirtles.musicroad.map.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.BasicAlertDialog
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.squirtles.musicroad.R
+import com.squirtles.musicroad.common.VerticalSpacer
+import com.squirtles.musicroad.ui.theme.Black
+import com.squirtles.musicroad.ui.theme.DarkGray
+import com.squirtles.musicroad.ui.theme.MusicRoadTheme
+import com.squirtles.musicroad.ui.theme.Primary
+import com.squirtles.musicroad.ui.theme.White
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun LoadingDialog(
+    onCloseClick: () -> Unit,
+) {
+    BasicAlertDialog(
+        onDismissRequest = {},
+    ) {
+        Surface(
+            modifier = Modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(16.dp),
+            color = White
+        ) {
+            Column(
+                modifier = Modifier.padding(top = 48.dp, bottom = 16.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center
+            ) {
+                CircularProgressIndicator(
+                    color = Primary
+                )
+
+                VerticalSpacer(16)
+
+                Text(
+                    text = stringResource(R.string.loading_current_location_dialog_text),
+                    color = Black,
+                    style = MaterialTheme.typography.bodyLarge
+                )
+
+                VerticalSpacer(24)
+
+                TextButton(
+                    onClick = { onCloseClick() },
+                    colors = ButtonDefaults.buttonColors().copy(
+                        containerColor = Color.Transparent,
+                        contentColor = DarkGray
+                    )
+                ) {
+                    Text(
+                        text = stringResource(R.string.close_loading_current_location_dialog)
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+fun LoadingDialogPreview() {
+    MusicRoadTheme {
+        LoadingDialog(
+            onCloseClick = {}
+        )
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,10 +2,16 @@
     <string name="app_name">MusicRoad</string>
 
     <!-- Main -->
+    <string name="main_need_permissions">위치와 마이크 권한이 필요합니다.</string>
     <string name="main_permission_deny_message">설정에서 권한을 허용해 주세요.</string>
     <string name="main_network_error_message">네트워크 연결이 원활하지 않습니다.</string>
     <string name="main_user_not_found_message">유저 정보가 존재하지 않습니다. 앱을 재설치 해주세요.</string>
     <string name="main_create_user_fail_message">유저 등록 실패. 문의해주세요</string>
+    <string name="request_permissions_title">권한 요청</string>
+    <string name="request_permissions_body">앱 실행을 위해\n위치와 마이크 권한이 필요합니다.</string>
+    <string name="confirm_text">확인</string>
+    <string name="snackbar_text">설정(앱 정보)에서 권한을 허용해주세요.</string>
+    <string name="action_to_setting">설정으로 이동</string>
 
     <!-- Map -->
     <string name="map_navigation_favorite_icon_description">픽 보관함 이동 버튼 아이콘</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -46,6 +46,10 @@
     <string name="search_music_album_description">노래 앨범 이미지</string>
     <string name="search_music_search_button_description">노래 검색 버튼</string>
 
+    <!-- Loading Location Dialog -->
+    <string name="loading_current_location_dialog_text">현재 위치 로딩 중...</string>
+    <string name="close_loading_current_location_dialog">종료</string>
+
     <!-- Delete Pick Dialog -->
     <string name="delete_pick_dialog_title">삭제하시겠습니까?</string>
     <string name="delete_pick_dialog_body">등록하신 픽이 삭제됩니다.</string>


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- resolved: #136 
- resolved: #137 

## 📝 작업 내용 및 코드
- 현재 위치를 가져오기 전까지 중앙 버튼이 비활성화되어 있지만 사용자에게 아무런 안내를 주지 않았습니다. 그 동안 현재 위치 로딩 다이얼로그를 띄워서 사용자 경험을 개선했습니다.
- 기존에는 최초 설치 시 권한을 모두 허용해도 현재 위치가 로딩되지 않는 문제가 있었습니다. 권한 허용이 되기 전에 지도가 이미 로딩이 되어버려서 사용자가 지도를 움직이지 않으면 현재 위치를 가져올 수 없었던 것으로 추측했습니다. 권한이 모두 요청되면 화면을 그리도록 했습니다.
- 또한 Android는 OS 차원에서 사용자가 권한을 2번 거절한 경우 더 이상의 동의 여부가 없는 것으로 간주하여 추가적인 권한 요청 창을 띄우지 않습니다. 2번 거절한 이후에는 화면에 스낵바를 띄워두고 클릭하면 설정 앱으로 이동하여 권한을 허용하도록 유도했습니다.

https://github.com/user-attachments/assets/c57af8ad-2765-4903-98a5-399273ca181e


## 💬 문제라면 문제..
- 스낵바에서 설정으로 이동 후 권한을 모두 허용하지 않고 다시 앱으로 돌아오면 스낵바가 사라집니다. onResume()에서 다시 스낵바를 띄워줬는데 왜 그러는지 모르겠습니다 ㅠ
- 권한을 모두 얻었을 때 화면을 그려서 이전보다 지도가 늦게 뜨는 것처럼 느껴집니다. (이전에는 스플래시에서 지도를 로딩했을 것입니다.) 그냥 어쩔 수 없는 부분이라고 생각해야할지,, 잘 모르겠습니다 최초 설치 후 실행 때만 이럽니다!