### PR TITLE
[hotfix] 픽 클릭 시 흰화면이 자주 뜨는 문제 해결

### DIFF
--- a/app/src/main/java/com/squirtles/musicroad/pick/DetailPickScreen.kt
+++ b/app/src/main/java/com/squirtles/musicroad/pick/DetailPickScreen.kt
@@ -202,7 +202,25 @@ fun DetailPickScreen(
         }
 
         DetailPickUiState.Error -> {
-            // TODO: pick 로딩 실패 or 담기 실패, 두 상태를 나눠야할지 고민
+            LaunchedEffect(Unit) {
+                Toast.makeText(
+                    context,
+                    context.getString(R.string.error_loading_pick_list),
+                    Toast.LENGTH_SHORT
+                ).show()
+            }
+
+            // Show default pick
+            DetailPick(
+                pick = DEFAULT_PICK,
+                isCreatedBySelf = false,
+                isFavorite = false,
+                userName = "",
+                isMusicVideoAvailable = false,
+                playerViewModel = playerViewModel,
+                onBackClick = onBackClick,
+                onActionClick = { }
+            )
         }
     }
 

--- a/app/src/main/java/com/squirtles/musicroad/pick/components/CommentText.kt
+++ b/app/src/main/java/com/squirtles/musicroad/pick/components/CommentText.kt
@@ -6,9 +6,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll


### PR DESCRIPTION
## #️⃣연관된 이슈

> --

## 📝작업 내용 및 코드

### 문제 상황
지도에서 픽을 클릭했을 때 흰화면만 뜨는 경우가 자주 발생했습니다. 

### 문제 발생 원인 확인 
1. 로그를 통해 확인한 결과 해당 문제가 발생하는 시점에 `DetailPickUiState`가 `Error`임을 확인했습니다. 
2. 대부분의 에러 발생 원인은 `PickViewModel`의 `fetchPick`에서 `fetchPickResult.isSuccess`가 `false`인 경우였습니다. 
3. 호출하는 코드를 확인해본 결과 기존 `FirebaseDataSourceImpl`의 `fetchPick`에서 pick을 불러오는 것을 기다리지 않고, 초깃값인 `var resultPick: Pick? = null`를 바로 리턴했습니다. 
4. `addOnSuccessListener` 안에서 `resultPick`을 설정하는 것이 `job` 완료된 후 실행될 수 있어 `await()`로 기다려도 null일 가능성이 있기 때문입니다. 

### 해결 방법
`suspendCancellableCoroutine`를 사용했습니다.
요청에 대한 결괏값을 callback으로 받아 외부 변수를 사용하지 않고 사용할 수 있도록 변경했습니다. 