### PR TITLE
[feature] QA 피드백 반영 및 플레이어 디자인 변경

### DIFF
--- a/app/src/main/java/com/squirtles/musicroad/map/components/ClusterBottomSheet.kt
+++ b/app/src/main/java/com/squirtles/musicroad/map/components/ClusterBottomSheet.kt
@@ -34,6 +34,7 @@ import com.squirtles.musicroad.common.FavoriteCountText
 import com.squirtles.musicroad.common.SongInfoText
 import com.squirtles.musicroad.common.TotalCountText
 import com.squirtles.musicroad.common.HorizontalSpacer
+import com.squirtles.musicroad.common.VerticalSpacer
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -62,6 +63,8 @@ fun ClusterBottomSheet(
                     .padding(start = DEFAULT_PADDING),
                 totalCount = pickList.size
             )
+            
+            VerticalSpacer(height = 8)
 
             LazyColumn {
                 items(

--- a/app/src/main/java/com/squirtles/musicroad/pick/DetailPickScreen.kt
+++ b/app/src/main/java/com/squirtles/musicroad/pick/DetailPickScreen.kt
@@ -324,11 +324,12 @@ private fun DetailPick(
                     )
                 )
                 .padding(innerPadding)
-                .verticalScroll(scrollState)
         ) {
             Column(
                 modifier = Modifier
-                    .fillMaxSize()
+                    .fillMaxWidth()
+                    .weight(1f)
+                    .verticalScroll(scrollState)
                     .padding(top = 10.dp),
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.spacedBy(10.dp),
@@ -369,33 +370,30 @@ private fun DetailPick(
 
                 PickInformation(formattedDate = pick.createdAt, favoriteCount = pick.favoriteCount)
 
-                CommentText(
-                    comment = pick.comment,
-                    scrollState = scrollState
-                )
+                CommentText(comment = pick.comment)
 
                 VerticalSpacer(height = 8)
+            }
 
-                if (pick.song.previewUrl.isBlank().not()) {
-                    MusicPlayer(
-                        previewUrl = pick.song.previewUrl,
-                        playerState = playerState,
-                        duration = duration,
-                        bufferPercentage = bufferPercentage,
-                        readyPlayer = { sourceUrl ->
-                            playerViewModel.readyPlayer(context, sourceUrl)
-                        },
-                        onSeekChanged = { timeMs ->
-                            playerViewModel.playerSeekTo(timeMs)
-                        },
-                        onReplayForwardClick = { replaySec ->
-                            playerViewModel.replayForward(replaySec)
-                        },
-                        onPauseToggle = {
-                            playerViewModel.togglePlayPause()
-                        },
-                    )
-                }
+            if (pick.song.previewUrl.isBlank().not()) {
+                MusicPlayer(
+                    previewUrl = pick.song.previewUrl,
+                    playerState = playerState,
+                    duration = duration,
+                    bufferPercentage = bufferPercentage,
+                    readyPlayer = { sourceUrl ->
+                        playerViewModel.readyPlayer(context, sourceUrl)
+                    },
+                    onSeekChanged = { timeMs ->
+                        playerViewModel.playerSeekTo(timeMs)
+                    },
+                    onReplayForwardClick = { replaySec ->
+                        playerViewModel.replayForward(replaySec)
+                    },
+                    onPauseToggle = {
+                        playerViewModel.togglePlayPause()
+                    },
+                )
             }
         }
     }

--- a/app/src/main/java/com/squirtles/musicroad/pick/DetailPickScreen.kt
+++ b/app/src/main/java/com/squirtles/musicroad/pick/DetailPickScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -60,6 +61,7 @@ import com.squirtles.musicroad.pick.components.music.MusicPlayer
 import com.squirtles.musicroad.ui.theme.Black
 import com.squirtles.musicroad.ui.theme.White
 import com.squirtles.musicroad.videoplayer.MusicVideoScreen
+import kotlinx.coroutines.launch
 import kotlin.math.absoluteValue
 
 @Composable
@@ -127,6 +129,7 @@ fun DetailPickScreen(
                 }
             }
 
+            val scrollScope = rememberCoroutineScope()
             val pagerState = rememberPagerState(
                 pageCount = { if (isMusicVideoAvailable) 2 else 1 }
             )
@@ -179,7 +182,11 @@ fun DetailPickScreen(
                                         fraction = 1f - pageOffset.coerceIn(0f, 1f)
                                     )
                                 },
-                            onBackClick = onBackClick,
+                            onBackClick = {
+                                scrollScope.launch {
+                                    pagerState.animateScrollToPage(page = DETAIL_PICK_TAB)
+                                }
+                            },
                         )
                     }
                 }

--- a/app/src/main/java/com/squirtles/musicroad/pick/components/CommentText.kt
+++ b/app/src/main/java/com/squirtles/musicroad/pick/components/CommentText.kt
@@ -1,15 +1,13 @@
 package com.squirtles.musicroad.pick.components
 
-import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -26,18 +24,17 @@ import com.squirtles.musicroad.ui.theme.White
 @Composable
 internal fun CommentText(
     comment: String,
-    scrollState: ScrollState,
     modifier: Modifier = Modifier
 ) {
     Text(
         text = comment.ifEmpty { stringResource(id = R.string.pick_comment_empty) },
         modifier = modifier
             .fillMaxWidth()
-            .height(100.dp)
+            .wrapContentHeight()
+            .heightIn(min = 100.dp)
             .padding(horizontal = 30.dp)
             .clip(shape = RoundedCornerShape(10.dp))
             .background(Dark)
-            .verticalScroll(scrollState)
             .padding(horizontal = 12.dp, vertical = 8.dp),
         style = MaterialTheme.typography.bodyLarge.copy(if (comment.isNotEmpty()) White else Gray)
     )
@@ -47,20 +44,13 @@ internal fun CommentText(
 @Composable
 private fun CommentTextPreview() {
     Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
-        CommentText(
-            comment = "",
-            scrollState = rememberScrollState()
-        )
+        CommentText(comment = "")
 
-        CommentText(
-            comment = "노래가 좋아서 추천합니다.",
-            scrollState = rememberScrollState()
-        )
+        CommentText(comment = "노래가 좋아서 추천합니다.")
 
         CommentText(
             comment = "노래가 너무너무너무너무너무너무너무너무너무너무너무너무너무너무너무너무너무너무너무너무너무너무너무너무너무너무" +
-                    "너무너무너무너무너무너무너무너무너무너무너무너무너무너무너무너무너무너무너무너무너무너무 좋아요",
-            scrollState = rememberScrollState()
+                    "너무너무너무너무너무너무너무너무너무너무너무너무너무너무너무너무너무너무너무너무너무너무 좋아요"
         )
     }
 }

--- a/app/src/main/java/com/squirtles/musicroad/pick/components/music/MusicPlayer.kt
+++ b/app/src/main/java/com/squirtles/musicroad/pick/components/music/MusicPlayer.kt
@@ -1,14 +1,18 @@
 package com.squirtles.musicroad.pick.components.music
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.squirtles.musicroad.common.Constants.DEFAULT_PADDING
 import com.squirtles.musicroad.musicplayer.PlayerState
+import com.squirtles.musicroad.ui.theme.PlayerBackground
 
 @Composable
 fun MusicPlayer(
@@ -30,7 +34,12 @@ fun MusicPlayer(
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 30.dp),
+                .padding(horizontal = 1.dp, vertical = DEFAULT_PADDING)
+                .background(
+                    color = PlayerBackground,
+                    shape = RoundedCornerShape(16.dp)
+                )
+                .padding(horizontal = 30.dp, vertical = DEFAULT_PADDING),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             PlayBar(
@@ -49,7 +58,7 @@ fun MusicPlayer(
                 },
                 onForwardClick = {
                     onReplayForwardClick(DEFAULT_FORWARD_SEC)
-                },
+                }
             )
         }
     }

--- a/app/src/main/java/com/squirtles/musicroad/pick/components/music/MusicPlayer.kt
+++ b/app/src/main/java/com/squirtles/musicroad/pick/components/music/MusicPlayer.kt
@@ -34,7 +34,7 @@ fun MusicPlayer(
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 1.dp, vertical = DEFAULT_PADDING)
+                .padding(horizontal = 8.dp, vertical = DEFAULT_PADDING)
                 .background(
                     color = PlayerBackground,
                     shape = RoundedCornerShape(16.dp)

--- a/app/src/main/java/com/squirtles/musicroad/ui/theme/Color.kt
+++ b/app/src/main/java/com/squirtles/musicroad/ui/theme/Color.kt
@@ -17,3 +17,5 @@ val Dark = Color(0xFF151515)
 val DarkGray = Color(0xFF646464)
 val Gray = Color(0xFFAAAAAA)
 val White = Color(0xFFFFFFFF)
+
+val PlayerBackground = Color(0xFF353535)

--- a/app/src/main/java/com/squirtles/musicroad/videoplayer/MusicVideoScreen.kt
+++ b/app/src/main/java/com/squirtles/musicroad/videoplayer/MusicVideoScreen.kt
@@ -1,5 +1,6 @@
 package com.squirtles.musicroad.videoplayer
 
+import androidx.activity.compose.BackHandler
 import androidx.annotation.OptIn
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
@@ -22,6 +23,8 @@ fun MusicVideoScreen(
     videoPlayerViewModel: VideoPlayerViewModel = hiltViewModel()
 ) {
     val isLoading by videoPlayerViewModel.isLoading.collectAsStateWithLifecycle()
+
+    BackHandler { onBackClick() }
 
     Box(modifier = modifier.fillMaxSize()) {
         MusicVideoPlayer(pick)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -53,7 +53,7 @@
 
     <!-- Search Music -->
     <string name="search">검색</string>
-    <string name="result">result</string>
+    <string name="result">검색 결과</string>
     <string name="search_music_album_description">노래 앨범 이미지</string>
     <string name="search_music_search_button_description">노래 검색 버튼</string>
     <string name="search_music_empty_description">검색 결과가 없습니다.</string>


### PR DESCRIPTION
## #️⃣연관된 이슈

> --

## 📝작업 내용 및 코드

1. 검색 결과 제목 변경 (result -> 검색 결과)
2. 마커 클러스터 목록에 Spacer추가
3. 뮤직비디오에서 뒤로가기 아이콘, 뒤로가기 버튼 클릭 시 플레이어로 이동
4. 픽 정보 화면 디자인 변경 
  a. 음악 정보 및 한마디 영역에 스크롤 적용
  b. 플레이어를 아래에 고정, 색상 적용

**변경된 플레이어 화면**

|기기1|기기2|
|-----|-----|
|<img width="200" alt="image" src="https://github.com/user-attachments/assets/c2614dbd-e303-4024-8034-74497906cf44">|<img width="200" alt="image" src="https://github.com/user-attachments/assets/b7c84e2d-fe25-41e0-b0d2-e022cbc07411">|
