### PR TITLE
[feature] 픽 담기 부분 보완

### DIFF
--- a/app/src/main/java/com/squirtles/musicroad/common/ThrottleFirst.kt
+++ b/app/src/main/java/com/squirtles/musicroad/common/ThrottleFirst.kt
@@ -1,0 +1,18 @@
+package com.squirtles.musicroad.common
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+
+internal fun <T> Flow<T>.throttleFirst(periodMillis: Long): Flow<T> {
+    require(periodMillis > 0) { "period should be positive" }
+    return flow {
+        var lastTime = 0L
+        collect { value ->
+            val currentTime = System.currentTimeMillis()
+            if (currentTime - lastTime >= periodMillis) {
+                lastTime = currentTime
+                emit(value)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/squirtles/musicroad/create/CreatePickViewModel.kt
+++ b/app/src/main/java/com/squirtles/musicroad/create/CreatePickViewModel.kt
@@ -15,16 +15,15 @@ import com.squirtles.domain.usecase.local.GetCurrentUserUseCase
 import com.squirtles.domain.usecase.music.FetchMusicVideoUseCase
 import com.squirtles.domain.usecase.music.SearchSongsUseCase
 import com.squirtles.domain.usecase.mypick.CreatePickUseCase
+import com.squirtles.musicroad.common.throttleFirst
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.debounce
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -159,20 +158,6 @@ class CreatePickViewModel @Inject constructor(
                     /* TODO: Firestore 등록 실패처리 */
                     _createPickUiState.emit(CreateUiState.Error)
                     Log.d("CreatePickViewModel", createResult.exceptionOrNull()?.message.toString())
-                }
-            }
-        }
-    }
-
-    private fun <T> Flow<T>.throttleFirst(periodMillis: Long): Flow<T> {
-        require(periodMillis > 0) { "period should be positive" }
-        return flow {
-            var lastTime = 0L
-            collect { value ->
-                val currentTime = System.currentTimeMillis()
-                if (currentTime - lastTime >= periodMillis) {
-                    lastTime = currentTime
-                    emit(value)
                 }
             }
         }

--- a/app/src/main/java/com/squirtles/musicroad/map/MapViewModel.kt
+++ b/app/src/main/java/com/squirtles/musicroad/map/MapViewModel.kt
@@ -11,9 +11,9 @@ import com.naver.maps.map.clustering.Clusterer
 import com.naver.maps.map.overlay.Marker
 import com.squirtles.domain.model.Pick
 import com.squirtles.domain.usecase.local.FetchLastLocationUseCase
-import com.squirtles.domain.usecase.pick.FetchPickInAreaUseCase
 import com.squirtles.domain.usecase.local.GetCurrentUserUseCase
 import com.squirtles.domain.usecase.local.SaveLastLocationUseCase
+import com.squirtles.domain.usecase.pick.FetchPickInAreaUseCase
 import com.squirtles.musicroad.map.marker.MarkerKey
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -145,6 +145,15 @@ class MapViewModel @Inject constructor(
                 pickList.forEach { pick ->
                     newKeyTagMap[MarkerKey(pick)] = pick.id
                     _picks[pick.id] = pick
+                }
+                _clickedMarkerState.value.clusterPickList?.let { clusterPickList -> // 클러스터 마커가 선택되어 있는 경우
+                    val updatedPickList = mutableListOf<Pick>()
+                    clusterPickList.forEach { pick ->
+                        _picks[pick.id]?.let { updatedPick ->
+                            updatedPickList.add(updatedPick)
+                        }
+                    }
+                    _clickedMarkerState.emit(_clickedMarkerState.value.copy(clusterPickList = updatedPickList.toList())) // 최신 픽 정보로 clusterPickList 업데이트
                 }
                 clusterer?.addAll(newKeyTagMap)
             }

--- a/app/src/main/java/com/squirtles/musicroad/pick/DetailPickScreen.kt
+++ b/app/src/main/java/com/squirtles/musicroad/pick/DetailPickScreen.kt
@@ -45,7 +45,10 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.lerp
 import androidx.core.view.WindowInsetsControllerCompat
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.flowWithLifecycle
 import com.squirtles.domain.model.Pick
 import com.squirtles.musicroad.R
 import com.squirtles.musicroad.common.VerticalSpacer
@@ -102,9 +105,7 @@ fun DetailPickScreen(
         }
 
         is DetailPickUiState.Success -> {
-            val favoriteAction by pickViewModel.favoriteAction.collectAsStateWithLifecycle(
-                FavoriteAction.NONE
-            )
+            val lifecycleOwner = LocalLifecycleOwner.current
             val pick = (uiState as DetailPickUiState.Success).pick
             val isFavorite = (uiState as DetailPickUiState.Success).isFavorite
             val isCreatedBySelf = pickViewModel.getUserId() == pick.createdBy.userId
@@ -139,22 +140,24 @@ fun DetailPickScreen(
                 pageCount = { if (isMusicVideoAvailable) 2 else 1 }
             )
 
-            LaunchedEffect(favoriteAction) {
-                when (favoriteAction) {
-                    FavoriteAction.ADDED -> {
-                        showProcessIndicator = false
-                        favoriteCount += 1
-                        context.showShortToast(context.getString(R.string.success_add_to_favorite))
-                    }
+            LaunchedEffect(Unit) {
+                pickViewModel.favoriteAction
+                    .flowWithLifecycle(lifecycleOwner.lifecycle, Lifecycle.State.STARTED)
+                    .collect { action ->
+                        when (action) {
+                            FavoriteAction.ADDED -> {
+                                showProcessIndicator = false
+                                favoriteCount += 1
+                                context.showShortToast(context.getString(R.string.success_add_to_favorite))
+                            }
 
-                    FavoriteAction.DELETED -> {
-                        showProcessIndicator = false
-                        favoriteCount -= 1
-                        context.showShortToast(context.getString(R.string.success_delete_at_favorite))
+                            FavoriteAction.DELETED -> {
+                                showProcessIndicator = false
+                                favoriteCount -= 1
+                                context.showShortToast(context.getString(R.string.success_delete_at_favorite))
+                            }
+                        }
                     }
-
-                    FavoriteAction.NONE -> {}
-                }
             }
 
             // 비디오 플레이어 설정

--- a/app/src/main/java/com/squirtles/musicroad/pick/DetailPickScreen.kt
+++ b/app/src/main/java/com/squirtles/musicroad/pick/DetailPickScreen.kt
@@ -119,7 +119,7 @@ fun DetailPickScreen(
 
                     isFavorite -> {
                         showProcessIndicator = true
-                        pickViewModel.onActionClick(
+                        pickViewModel.toggleFavoritePick(
                             pickId = pickId,
                             isAdding = false
                         )
@@ -127,7 +127,7 @@ fun DetailPickScreen(
 
                     else -> {
                         showProcessIndicator = true
-                        pickViewModel.onActionClick(
+                        pickViewModel.toggleFavoritePick(
                             pickId = pickId,
                             isAdding = true
                         )

--- a/app/src/main/java/com/squirtles/musicroad/pick/DetailPickScreen.kt
+++ b/app/src/main/java/com/squirtles/musicroad/pick/DetailPickScreen.kt
@@ -100,6 +100,9 @@ fun DetailPickScreen(
         }
 
         is DetailPickUiState.Success -> {
+            val favoriteAction by pickViewModel.favoriteAction.collectAsStateWithLifecycle(
+                FavoriteAction.NONE
+            )
             val pick = (uiState as DetailPickUiState.Success).pick
             val isFavorite = (uiState as DetailPickUiState.Success).isFavorite
             val isCreatedBySelf = pickViewModel.getUserId() == pick.createdBy.userId
@@ -113,27 +116,44 @@ fun DetailPickScreen(
 
                     isFavorite -> {
                         showProcessIndicator = true
-                        pickViewModel.deleteAtFavorite(pickId) {
-                            showProcessIndicator = false
-                            favoriteCount -= 1
-                            context.showShortToast(context.getString(R.string.success_delete_at_favorite))
-                        }
+                        pickViewModel.onActionClick(
+                            pickId = pickId,
+                            isAdding = false
+                        )
                     }
 
                     else -> {
                         showProcessIndicator = true
-                        pickViewModel.addToFavorite(pickId) {
-                            showProcessIndicator = false
-                            favoriteCount += 1
-                            context.showShortToast(context.getString(R.string.success_add_to_favorite))
-                        }
+                        pickViewModel.onActionClick(
+                            pickId = pickId,
+                            isAdding = true
+                        )
                     }
                 }
             }
 
+
             val pagerState = rememberPagerState(
                 pageCount = { if (isMusicVideoAvailable) 2 else 1 }
             )
+
+            LaunchedEffect(favoriteAction) {
+                when (favoriteAction) {
+                    FavoriteAction.ADDED -> {
+                        showProcessIndicator = false
+                        favoriteCount += 1
+                        context.showShortToast(context.getString(R.string.success_add_to_favorite))
+                    }
+
+                    FavoriteAction.DELETED -> {
+                        showProcessIndicator = false
+                        favoriteCount -= 1
+                        context.showShortToast(context.getString(R.string.success_delete_at_favorite))
+                    }
+
+                    FavoriteAction.NONE -> {}
+                }
+            }
 
             // 비디오 플레이어 설정
             LaunchedEffect(pick) {

--- a/app/src/main/java/com/squirtles/musicroad/pick/DetailPickScreen.kt
+++ b/app/src/main/java/com/squirtles/musicroad/pick/DetailPickScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -102,6 +103,7 @@ fun DetailPickScreen(
             val pick = (uiState as DetailPickUiState.Success).pick
             val isFavorite = (uiState as DetailPickUiState.Success).isFavorite
             val isCreatedBySelf = pickViewModel.getUserId() == pick.createdBy.userId
+            var favoriteCount by rememberSaveable { mutableIntStateOf(pick.favoriteCount) }
             val onActionClick: () -> Unit = {
                 when {
                     isCreatedBySelf -> {
@@ -113,6 +115,7 @@ fun DetailPickScreen(
                         showProcessIndicator = true
                         pickViewModel.deleteAtFavorite(pickId) {
                             showProcessIndicator = false
+                            favoriteCount -= 1
                             context.showShortToast(context.getString(R.string.success_delete_at_favorite))
                         }
                     }
@@ -121,6 +124,7 @@ fun DetailPickScreen(
                         showProcessIndicator = true
                         pickViewModel.addToFavorite(pickId) {
                             showProcessIndicator = false
+                            favoriteCount += 1
                             context.showShortToast(context.getString(R.string.success_add_to_favorite))
                         }
                     }
@@ -154,8 +158,9 @@ fun DetailPickScreen(
                         DetailPick(
                             pick = pick,
                             isCreatedBySelf = isCreatedBySelf,
-                            isFavorite = isFavorite, // TODO
+                            isFavorite = isFavorite,
                             userName = pick.createdBy.userName,
+                            favoriteCount = favoriteCount,
                             isMusicVideoAvailable = isMusicVideoAvailable,
                             playerViewModel = playerViewModel,
                             onBackClick = onBackClick,
@@ -216,6 +221,7 @@ fun DetailPickScreen(
                 isCreatedBySelf = false,
                 isFavorite = false,
                 userName = "",
+                favoriteCount = 0,
                 isMusicVideoAvailable = false,
                 playerViewModel = playerViewModel,
                 onBackClick = onBackClick,
@@ -259,6 +265,7 @@ private fun DetailPick(
     isCreatedBySelf: Boolean,
     isFavorite: Boolean,
     userName: String,
+    favoriteCount: Int,
     isMusicVideoAvailable: Boolean,
     playerViewModel: PlayerViewModel,
     onBackClick: () -> Unit,
@@ -360,7 +367,10 @@ private fun DetailPick(
                     }
                 }
 
-                PickInformation(formattedDate = pick.createdAt, favoriteCount = pick.favoriteCount)
+                PickInformation(
+                    formattedDate = pick.createdAt,
+                    favoriteCount = favoriteCount
+                )
 
                 CommentText(
                     comment = pick.comment,
@@ -406,6 +416,7 @@ private fun DetailPickPreview() {
         isCreatedBySelf = false,
         isFavorite = false,
         userName = "짱구",
+        favoriteCount = 0,
         isMusicVideoAvailable = true,
         playerViewModel = PlayerViewModel(),
         onBackClick = {},

--- a/app/src/main/java/com/squirtles/musicroad/pick/PickViewModel.kt
+++ b/app/src/main/java/com/squirtles/musicroad/pick/PickViewModel.kt
@@ -13,12 +13,19 @@ import com.squirtles.domain.usecase.local.GetCurrentUserUseCase
 import com.squirtles.domain.usecase.mypick.DeletePickUseCase
 import com.squirtles.domain.usecase.pick.FetchIsFavoriteUseCase
 import com.squirtles.domain.usecase.pick.FetchPickUseCase
+import com.squirtles.musicroad.common.throttleFirst
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+
+enum class FavoriteAction {
+    ADDED, DELETED, NONE
+}
 
 @HiltViewModel
 class PickViewModel @Inject constructor(
@@ -35,6 +42,25 @@ class PickViewModel @Inject constructor(
 
     private var _currentTab = DETAIL_PICK_TAB
     val currentTab get() = _currentTab
+
+    private val _favoriteAction = MutableSharedFlow<FavoriteAction>()
+    val favoriteAction = _favoriteAction.asSharedFlow()
+
+    private val actionClick = MutableSharedFlow<Pair<String, Boolean>>()
+
+    init {
+        viewModelScope.launch {
+            actionClick
+                .throttleFirst(1000)
+                .collect { (pickId, isAdding) ->
+                    if (isAdding) {
+                        addToFavoritePicks(pickId)
+                    } else {
+                        deleteFromFavoritePicks(pickId)
+                    }
+                }
+        }
+    }
 
     fun getUserId() = getCurrentUserUseCase().userId
 
@@ -67,6 +93,12 @@ class PickViewModel @Inject constructor(
         }
     }
 
+    fun onActionClick(pickId: String, isAdding: Boolean) {
+        viewModelScope.launch {
+            actionClick.emit(pickId to isAdding)
+        }
+    }
+
     fun deletePick(pickId: String) {
         viewModelScope.launch {
             _detailPickUiState.emit(DetailPickUiState.Loading)
@@ -80,11 +112,11 @@ class PickViewModel @Inject constructor(
         }
     }
 
-    fun addToFavorite(pickId: String, onAddToFavoriteSuccess: () -> Unit) {
+    private fun addToFavoritePicks(pickId: String) {
         viewModelScope.launch {
             createFavoriteUseCase(pickId, getUserId())
                 .onSuccess {
-                    onAddToFavoriteSuccess()
+                    _favoriteAction.emit(FavoriteAction.ADDED)
                     val currentUiState = _detailPickUiState.value as? DetailPickUiState.Success
                     currentUiState?.let { successState ->
                         _detailPickUiState.emit(successState.copy(isFavorite = true))
@@ -96,11 +128,11 @@ class PickViewModel @Inject constructor(
         }
     }
 
-    fun deleteAtFavorite(pickId: String, onDeleteAtFavoriteSuccess: () -> Unit) {
+    private fun deleteFromFavoritePicks(pickId: String) {
         viewModelScope.launch {
             deleteFavoriteUseCase(pickId, getUserId())
                 .onSuccess {
-                    onDeleteAtFavoriteSuccess()
+                    _favoriteAction.emit(FavoriteAction.DELETED)
                     val currentUiState = _detailPickUiState.value as? DetailPickUiState.Success
                     currentUiState?.let { successState ->
                         _detailPickUiState.emit(successState.copy(isFavorite = false))

--- a/app/src/main/java/com/squirtles/musicroad/pick/PickViewModel.kt
+++ b/app/src/main/java/com/squirtles/musicroad/pick/PickViewModel.kt
@@ -24,7 +24,7 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 enum class FavoriteAction {
-    ADDED, DELETED, NONE
+    ADDED, DELETED
 }
 
 @HiltViewModel

--- a/app/src/main/java/com/squirtles/musicroad/pick/PickViewModel.kt
+++ b/app/src/main/java/com/squirtles/musicroad/pick/PickViewModel.kt
@@ -93,7 +93,7 @@ class PickViewModel @Inject constructor(
         }
     }
 
-    fun onActionClick(pickId: String, isAdding: Boolean) {
+    fun toggleFavoritePick(pickId: String, isAdding: Boolean) {
         viewModelScope.launch {
             actionClick.emit(pickId to isAdding)
         }

--- a/data/src/main/java/com/squirtles/data/datasource/remote/firebase/FirebaseDataSourceImpl.kt
+++ b/data/src/main/java/com/squirtles/data/datasource/remote/firebase/FirebaseDataSourceImpl.kt
@@ -281,8 +281,15 @@ class FirebaseDataSourceImpl @Inject constructor(
             db.collection(COLLECTION_FAVORITES)
                 .add(firebaseFavorite)
                 .addOnSuccessListener {
-                    updateFavoriteCount(pickId) // 클라우드 함수 호출
-                    continuation.resume(true)
+                    // favorites에 문서 생성 후 클라우드 함수가 완료됐을 때 담기 완료
+                    CoroutineScope(Dispatchers.IO).launch {
+                        try {
+                            updateFavoriteCount(pickId) // 클라우드 함수 호출
+                            continuation.resume(true)
+                        } catch (e: Exception) {
+                            continuation.resumeWithException(e)
+                        }
+                    }
                 }
                 .addOnFailureListener { exception ->
                     Log.e("FirebaseDataSourceImpl", "Failed to create favorite", exception)
@@ -298,8 +305,15 @@ class FirebaseDataSourceImpl @Inject constructor(
                 db.collection(COLLECTION_FAVORITES).document(document.id)
                     .delete()
                     .addOnSuccessListener {
-                        updateFavoriteCount(pickId) // 클라우드 함수 호출
-                        continuation.resume(true)
+                        // favorites에 문서 삭제 후 클라우드 함수가 완료됐을 때 담기 해제 완료
+                        CoroutineScope(Dispatchers.IO).launch {
+                            try {
+                                updateFavoriteCount(pickId) // 클라우드 함수 호출
+                                continuation.resume(true)
+                            } catch (e: Exception) {
+                                continuation.resumeWithException(e)
+                            }
+                        }
                     }
                     .addOnFailureListener { exception ->
                         Log.w(
@@ -375,19 +389,18 @@ class FirebaseDataSourceImpl @Inject constructor(
         }
     }
 
-    private fun updateFavoriteCount(pickId: String) {
-        CoroutineScope(Dispatchers.IO).launch {
-            try {
-                val result = cloudFunctionHelper.updateFavoriteCount(pickId)
-                result.onSuccess {
-                    Log.d("FirebaseDataSourceImpl", "Success to update favorite count")
-                }
-                .onFailure { exception ->
-                    Log.e("FirebaseDataSourceImpl", "Failed to update favorite count", exception)
-                }
-            } catch (e: Exception) {
-                Log.e("FirebaseDataSourceImpl", "Exception occurred while updating favorite count", e)
+    private suspend fun updateFavoriteCount(pickId: String) {
+        try {
+            val result = cloudFunctionHelper.updateFavoriteCount(pickId)
+            result.onSuccess {
+                Log.d("FirebaseDataSourceImpl", "Success to update favorite count")
+            }.onFailure { exception ->
+                Log.e("FirebaseDataSourceImpl", "Failed to update favorite count", exception)
+                throw exception
             }
+        } catch (e: Exception) {
+            Log.e("FirebaseDataSourceImpl", "Exception occurred while updating favorite count", e)
+            throw e
         }
     }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- resolved #143 

## 📝 작업 내용 및 코드
- 픽 담기/해제 시 정보 화면에서 개수 증가/감소
- 바텀시트/인포윈도우를 통해 진입한 정보 화면에서 픽 담기/해제 후 뒤로 돌아갔을 때 바텀시트/인포윈도우에 담은 수 반영
- 픽 담기/해제 버튼에 throttleFirst 적용

https://github.com/user-attachments/assets/7e816f8e-31c8-4990-b1e1-a27bd04131c5

### 픽 담기/해제 시 정보 화면에서 개수 증가/감소

픽 정보 화면으로 처음 진입할 때 픽 정보를 불러오고 이때의 담은 수를 정보 화면에 표시한다. 이후에 담기/해제에 따라 서버의 favorites 컬렉션에서는 삭제되지만 화면에서는 아무런 작업도 하고 있지 않았다. 따라서 담기/해제 동작을 해도 처음 불러왔을 때의 담은 수만을 계속 보여주고 있었다.

아래처럼 Success일 때 favoriteCount 값을 가지고 있는 변수를 만들었다.

```kotlin
var favoriteCount by rememberSaveable { mutableIntStateOf(pick.favoriteCount) }
val onActionClick: () -> Unit = {
      when {
          // ...
          isFavorite -> {
              showProcessIndicator = true
              pickViewModel.deleteAtFavorite(pickId) {
                  showProcessIndicator = false
                  favoriteCount -= 1 // 추가
                  context.showShortToast(context.getString(R.string.success_delete_at_favorite))
              }
          }

          else -> {
              showProcessIndicator = true
              pickViewModel.addToFavorite(pickId) {
                  showProcessIndicator = false
                  favoriteCount += 1 // 추가
                  context.showShortToast(context.getString(R.string.success_add_to_favorite))
              }
          }
      }
  }
```

기존에는 pick.favoriteCount를 계속 보여주고 있었다면 favoriteCount를 보여주면 된다. 그럼 정보 화면에서 담기 하면 ui의 숫자도 1 증가하고, 해제하면 1 감소한다.

담긴 수가 0인 어떤 픽에 대해 두 명의 사용자가 같은 픽을 담기를 시도하면 둘 다 1로 표시된다. 왜냐하면 담는 개수를 실시간으로 반영하지 않기 때문이다. 하지만 실시간 처리가 굳이 되지 않아도 괜찮다고 생각해서 하지 않았다. 정보 화면을 나갔다가 돌아오면 반영되어 있기 때문이다.

### 바텀 시트/인포윈도우를 통해 진입한 정보 화면에서 픽 담기/해제 후 뒤로 돌아갔을 때 바텀 시트/인포윈도우에 담은 수 반영

단말 마커를 누르면 인포윈도우가 나오고 이를 클릭하여 정보 화면으로 진입할 수 있다. 클러스터 마커를 누르면 바텀 시트가 나오고 목록에서 항목을 눌러 정보 화면으로 진입할 수 있다. 여기서 픽 담기/해제를 수행하고 뒤로 가기를 하면 다시 클릭했던 마커에 대한 정보(인포윈도우 or 바텀 시트)가 보이게 된다. 그런데 여기서 담은 수가 반영되어 있지 않은 문제가 있었다.

지도로 돌아오면 `fetchPicksInBounds()`를 수행하기 때문에 최신 정보를 가져올 텐데 왜 그런지 처음엔 몰랐다. fetch에서 최신 픽 정보를 가져오지만 뷰모델 안의 픽 정보 맵과 클러스터러의 마커만 업데이트하고 있었다. 클러스터 마커를 클릭하면 그때 clickedMarkerState의 clusterPickList를 업데이트하는데, [지도 화면 → 클러스터 마커 클릭 → 바텀 시트의 픽 클릭 → 정보 화면 → 픽 담기/해제 후 뒤로 가기 → 지도 화면]의 흐름일 때 clusterPickList를 업데이트 하는 것은 밑줄 친 클러스터 마커 클릭일 때이다. 그러나 픽 정보가 업데이트 되는 시점은 빨간색 배경의 글자인 지도 화면일 때이므로 두 번째 지도 화면에서는 이전의 clusterPickList가 보여지는 것이었다. 지도 화면으로 돌아왔을 때 클러스터 마커가 클릭되어 있다면 clusterPickList도 새로운 픽 정보로 함께 업데이트해줘야 한다.

```kotlin
_clickedMarkerState.value.clusterPickList?.let { clusterPickList -> // 클러스터 마커가 선택되어 있는 경우
    val updatedPickList = mutableListOf<Pick>()
    clusterPickList.forEach { pick ->
        _picks[pick.id]?.let { updatedPick ->
            updatedPickList.add(updatedPick)
        }
    }
    _clickedMarkerState.emit(_clickedMarkerState.value.copy(clusterPickList = updatedPickList.toList())) // 최신 픽 정보로 clusterPickList 업데이트
}
```

MapViewModel에서 fetchPickInBounds() 부분에 위 코드를 추가해줬다.

단말 마커가 선택되어 있을 때 업데이트를 하지 않아도 되는 것은 선택된 단말 마커의 픽 정보는 pickId 값으로 관리하기 때문에 이는 변하지 않아서 업데이트 하지 않아도 된다. 인포윈도우의 픽 정보를 pickId로 새로 업데이트된 맵에서 픽 정보를 가져오기 때문이다.

그리고 이 부분을 생각하다보니 담은 수가 picks의 favoriteCount에 반영이 되었다는 것을 보장할 수 있을까?가 갑자기 의문이 들어서 FirebaseDataSourceImpl에서 픽을 담기/해제하는 부분을 봤다. 왜냐하면 인포윈도우나 바텀 시트에 표시되는 픽들의 담은 수는 picks의 favoriteCount 값을 표시하기 때문이다. 기존 코드는 아래와 같았다.

```kotlin
// favorites에 문서 추가/삭제 성공 시 클라우드 함수 호출 & resume
.addOnSuccessListener {
    updateFavoriteCount(pickId) // 클라우드 함수 호출
    continuation.resume(true)
}

private fun updateFavoriteCount(pickId: String) {
    CoroutineScope(Dispatchers.IO).launch {
        try {
            val result = cloudFunctionHelper.updateFavoriteCount(pickId)
            result.onSuccess {
                Log.d("FirebaseDataSourceImpl", "Success to update favorite count")
            }
            .onFailure { exception ->
                Log.e("FirebaseDataSourceImpl", "Failed to update favorite count", exception)
            }
        } catch (e: Exception) {
            Log.e("FirebaseDataSourceImpl", "Exception occurred while updating favorite count", e)
        }
    }
}
```

위 코드를 보면 클라우드 함수가 비동기적으로 실행되기 때문에 클라우드 함수의 실행 결과에 상관없이 `continuation.resume(true)`를 하여 favorites에 문서가 추가/삭제는 되었지만 picks에 favoriteCount가 증가/감소했는지 보장할 수 없는 상태였다.

따라서 클라우드 함수를 suspend로 변경하여 클라우드 함수의 호출이 완료된 후에 `continuation.resume(true)`이 될 수 있도록 했다.

이렇게 하니 인포윈도우나 바텀 시트로부터 정보 화면으로 진입 후 담기/해제하고 뒤로 갔을 때 담은 수가 잘 반영되었다.

### 픽 담기/해제 버튼에도 throttleFirst 적용

픽 등록과 같은 문제가 발생할 수 있어 픽 담기/해제 버튼에도 throttleFirst를 적용했다.

![제목 없음](https://github.com/user-attachments/assets/1716ae4f-5acb-4010-9937-58e8c7a89d98)

픽 담기/해제를 시작했을 때와 완료되었을 때를 로그로 찍어보니 대략 1초 정도 걸리는 작업이었다. 기존에 `updateFavorite()`가 suspend가 아니었을 때는 담기/해제-완료까지 텀이 짧았었는데 클라우드 함수가 완료되는 시간이 조금 있는 것 같다. 아무튼 위 로그를 보고 오래 걸릴 때는 2초 정도가 걸릴 때도 있는 것 같지만 어차피 픽 담기/해제 버튼을 누르면 화면 위에 로딩 인디케이터가 뜨며 화면에 있는 것들과 아무것도 상호작용 할 수 없게 만들어뒀다. ThrottleFirst로 픽 담기/해제 버튼은 1초 이내의 클릭이 무시되도록 했다.

픽을 담고 해제하는 동작은 뷰모델 안에, 완료됐을 때의 동작은 스크린에 있었다. 따라서 뷰모델에 담기 버튼 클릭 이벤트를 관리하는 MutableSharedFlow와 담기가 완료되었을 때의 이벤트를 관리하는 MutableSharedFlow를 만들었다.

버튼을 클릭했을 때 버튼 클릭 이벤트를 관리하는 MutableSharedFlow에 값을 발행한다. 뷰모델에서는 이 MutableSharedFlow를 관찰하되 1초 이내의 이벤트는 무시한다. 여기서 받은 값으로 뷰모델 내의 픽 담기/해제 동작을 수행한다.

픽 담기/해제가 완료되면 완료되었을 때의 이벤트를 관리하는 MutableSharedFlow에 값을 발행한다. 스크린에서 SharedFlow를 관찰하고 값에 따라 완료되었을 때의 동작을 수행한다.

> when문을 LaunchedEffect 안에 넣지 않으면 담기를 완료했을 때 정보 화면의 담기 수가 무한히 증가한다. 해제를 완료했을 때는 담기 수가 무한히 감소한다. ㅎㅎ 

FavoriteAction 클래스에 NONE은 만들고 싶지 않았지만 SharedFlow를 구독할 때 초기 값을 지정해야 해서 넣었다..

```kotlin
enum class FavoriteAction {
    ADDED, DELETED, NONE
}

// PickViewModel
private val _favoriteAction = MutableSharedFlow<FavoriteAction>()
val favoriteAction = _favoriteAction.asSharedFlow()

private val actionClick = MutableSharedFlow<Pair<String, Boolean>>()

init {
    viewModelScope.launch {
        actionClick
            .throttleFirst(1000)
            .collect { (pickId, isAdding) ->
                if (isAdding) {
                    addToFavoritePicks(pickId)
                } else {
                    deleteFromFavoritePicks(pickId)
                }
            }
    }
}

fun onActionClick(pickId: String, isAdding: Boolean) {
    viewModelScope.launch {
        actionClick.emit(pickId to isAdding)
    }
}

private fun addToFavoritePicks(pickId: String) {
    viewModelScope.launch {
        createFavoriteUseCase(pickId, getUserId())
            .onSuccess {
                _favoriteAction.emit(FavoriteAction.ADDED)
                // ...
                
private fun deleteFromFavoritePicks(pickId: String) {
    viewModelScope.launch {
        deleteFavoriteUseCase(pickId, getUserId())
            .onSuccess {
                _favoriteAction.emit(FavoriteAction.DELETED)
                // ...
                
// DetailPickScreen
val favoriteAction by pickViewModel.favoriteAction.collectAsStateWithLifecycle(
    FavoriteAction.NONE
)

val onActionClick: () -> Unit = {
    when {
        isFavorite -> {
            showProcessIndicator = true
            pickViewModel.onActionClick(
                pickId = pickId,
                isAdding = false
            )
        }

        else -> {
            showProcessIndicator = true
            pickViewModel.onActionClick(
                pickId = pickId,
                isAdding = true
            )
        }
    }
}

LaunchedEffect(favoriteAction) {
    when (favoriteAction) {
        FavoriteAction.ADDED -> {
            showProcessIndicator = false
            favoriteCount += 1
            context.showShortToast(context.getString(R.string.success_add_to_favorite))
        }

        FavoriteAction.DELETED -> {
            showProcessIndicator = false
            favoriteCount -= 1
            context.showShortToast(context.getString(R.string.success_delete_at_favorite))
        }

        FavoriteAction.NONE -> {}
    }
}
```
