### PR TITLE
[fix] 오디오 비주얼라이저가 노래 정보를 가리지 않도록 수정

### DIFF
--- a/app/src/main/java/com/squirtles/musicroad/pick/DetailPickScreen.kt
+++ b/app/src/main/java/com/squirtles/musicroad/pick/DetailPickScreen.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.lerp
+import androidx.compose.ui.zIndex
 import androidx.core.view.WindowInsetsControllerCompat
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -336,13 +337,15 @@ private fun DetailPick(
             ) {
                 SongInfo(
                     song = pick.song,
-                    dynamicOnBackgroundColor = onDynamicBackgroundColor
+                    dynamicOnBackgroundColor = onDynamicBackgroundColor,
+                    modifier = Modifier.zIndex(1f)
                 )
 
                 Box(
                     modifier = Modifier
                         .fillMaxWidth()
                         .align(Alignment.CenterHorizontally)
+                        .zIndex(0f)
                 ) {
                     if (playerState.isReady) {
                         CircleAlbumCover(

--- a/app/src/main/java/com/squirtles/musicroad/pick/components/SongInfo.kt
+++ b/app/src/main/java/com/squirtles/musicroad/pick/components/SongInfo.kt
@@ -1,8 +1,12 @@
 package com.squirtles.musicroad.pick.components
 
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -11,19 +15,25 @@ import com.squirtles.domain.model.Song
 @Composable
 internal fun SongInfo(
     song: Song,
-    dynamicOnBackgroundColor: Color
+    dynamicOnBackgroundColor: Color,
+    modifier: Modifier,
 ) {
-    Text(
-        text = song.songName,
-        color = dynamicOnBackgroundColor,
-        textAlign = TextAlign.Center,
-        style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold)
-    )
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = song.songName,
+            color = dynamicOnBackgroundColor,
+            textAlign = TextAlign.Center,
+            style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold)
+        )
 
-    Text(
-        text = song.artistName,
-        color = dynamicOnBackgroundColor,
-        textAlign = TextAlign.Center,
-        style = MaterialTheme.typography.bodyLarge
-    )
+        Text(
+            text = song.artistName,
+            color = dynamicOnBackgroundColor,
+            textAlign = TextAlign.Center,
+            style = MaterialTheme.typography.bodyLarge
+        )
+    }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> --

## 📝작업 내용 및 코드

### 문제 상항 
오디오 비주얼라이저가 글자를 가리는 문제

### 해결 방법
`zIndex`를 조절해서 글자가 더 위로 가도록 수정했습니다. 

**실행 화면**
|Before|After|
|------|------|
|<img width=200 src="https://github.com/user-attachments/assets/06be3ae9-8a48-4088-bab2-5fb9e175c74e" />|<img width=200 src="https://github.com/user-attachments/assets/56d5fa45-32fc-4945-96b0-ad11f6f9c9a8" />|

