### PR TITLE
[feature] 픽 삭제 시 담은 픽과 유저 정보 관리 DB에서도 삭제

### DIFF
--- a/app/src/main/java/com/squirtles/musicroad/pick/PickViewModel.kt
+++ b/app/src/main/java/com/squirtles/musicroad/pick/PickViewModel.kt
@@ -70,7 +70,7 @@ class PickViewModel @Inject constructor(
     fun deletePick(pickId: String) {
         viewModelScope.launch {
             _detailPickUiState.emit(DetailPickUiState.Loading)
-            deletePickUseCase(pickId)
+            deletePickUseCase(pickId, getUserId())
                 .onSuccess {
                     _detailPickUiState.emit(DetailPickUiState.Deleted)
                 }

--- a/data/src/main/java/com/squirtles/data/datasource/remote/firebase/FirebaseDataSourceImpl.kt
+++ b/data/src/main/java/com/squirtles/data/datasource/remote/firebase/FirebaseDataSourceImpl.kt
@@ -5,6 +5,7 @@ import com.firebase.geofire.GeoFireUtils
 import com.firebase.geofire.GeoLocation
 import com.google.android.gms.tasks.Task
 import com.google.android.gms.tasks.Tasks
+import com.google.firebase.firestore.DocumentReference
 import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.FieldValue
 import com.google.firebase.firestore.FirebaseFirestore
@@ -192,20 +193,27 @@ class FirebaseDataSourceImpl @Inject constructor(
                 }
         }
 
-    override suspend fun deletePick(pickId: String): Boolean {
+    override suspend fun deletePick(pickId: String, userId: String): Boolean {
+        val pickDocument = db.collection(COLLECTION_PICKS).document(pickId)
+        val userDocument = db.collection(COLLECTION_USERS).document(userId)
+        val favoriteDocuments = fetchFavoriteDocuments(pickId)
+
         return suspendCancellableCoroutine { continuation ->
-            db.collection("picks").document(pickId)
-                .delete()
-                .addOnSuccessListener {
-                    continuation.resume(true)
+            db.runTransaction { transaction ->
+                transaction.delete(pickDocument)
+
+                favoriteDocuments.forEach { document ->
+                    transaction.delete(document)
                 }
-                .addOnFailureListener { exception ->
-                    Log.e("FirebaseDataSourceImpl", "Failed to delete pick", exception)
-                    continuation.resumeWithException(exception)
-                }
+
+                transaction.update(userDocument, FIELD_MY_PICKS, FieldValue.arrayRemove(pickId))
+            }.addOnSuccessListener { _ ->
+                continuation.resume(true)
+            }.addOnFailureListener { e ->
+                Log.w(TAG_LOG, "Transaction failure.", e)
+                continuation.resumeWithException(e)
+            }
         }
-        // TODO: 유저가 등록한 리스트에서 이 픽 id를 삭제
-        // TODO: favorite에서 이 픽 id 삭제
     }
 
     override suspend fun fetchMyPicks(userId: String): List<Pick> {
@@ -391,7 +399,29 @@ class FirebaseDataSourceImpl @Inject constructor(
         }
     }
 
+    private suspend fun fetchFavoriteDocuments(pickId: String): List<DocumentReference> {
+        return suspendCancellableCoroutine { continuation ->
+            db.collection(COLLECTION_FAVORITES)
+                .whereEqualTo(FIELD_PICK_ID, pickId)
+                .get()
+                .addOnSuccessListener { querySnapShot ->
+                    val documentIds = querySnapShot.documents.map { it.id }
+                    val documentRefs = mutableListOf<DocumentReference>()
+                    documentIds.forEach { id ->
+                        documentRefs.add(db.collection(COLLECTION_FAVORITES).document(id))
+                    }
+                    continuation.resume(documentRefs)
+                }
+                .addOnFailureListener { e ->
+                    Log.w(TAG_LOG, "Failed to fetch favorite documents id", e)
+                    continuation.resumeWithException(e)
+                }
+        }
+    }
+
     companion object {
+        private const val TAG_LOG = "FirebaseDataSourceImpl"
+
         private const val COLLECTION_FAVORITES = "favorites"
         private const val COLLECTION_PICKS = "picks"
         private const val COLLECTION_USERS = "users"
@@ -399,5 +429,6 @@ class FirebaseDataSourceImpl @Inject constructor(
         private const val FIELD_PICK_ID = "pickId"
         private const val FIELD_USER_ID = "userId"
         private const val FIELD_ADDED_AT = "addedAt"
+        private const val FIELD_MY_PICKS = "myPicks"
     }
 }

--- a/data/src/main/java/com/squirtles/data/repository/FirebaseRepositoryImpl.kt
+++ b/data/src/main/java/com/squirtles/data/repository/FirebaseRepositoryImpl.kt
@@ -48,9 +48,9 @@ class FirebaseRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun deletePick(pickId: String): Result<Boolean> {
+    override suspend fun deletePick(pickId: String, userId: String): Result<Boolean> {
         return handleResult {
-            firebaseRemoteDataSource.deletePick(pickId)
+            firebaseRemoteDataSource.deletePick(pickId, userId)
         }
     }
 

--- a/domain/src/main/java/com/squirtles/domain/datasource/FirebaseRemoteDataSource.kt
+++ b/domain/src/main/java/com/squirtles/domain/datasource/FirebaseRemoteDataSource.kt
@@ -10,7 +10,7 @@ interface FirebaseRemoteDataSource {
     suspend fun fetchPick(pickID: String): Pick?
     suspend fun fetchPicksInArea(lat: Double, lng: Double, radiusInM: Double): List<Pick>
     suspend fun createPick(pick: Pick): String
-    suspend fun deletePick(pickId: String): Boolean
+    suspend fun deletePick(pickId: String, userId: String): Boolean
 
     suspend fun fetchMyPicks(userId: String): List<Pick>
     suspend fun fetchFavoritePicks(userId: String): List<Pick>

--- a/domain/src/main/java/com/squirtles/domain/repository/FirebaseRepository.kt
+++ b/domain/src/main/java/com/squirtles/domain/repository/FirebaseRepository.kt
@@ -10,7 +10,7 @@ interface FirebaseRepository {
     suspend fun fetchPick(pickID: String): Result<Pick>
     suspend fun fetchPicksInArea(lat: Double, lng: Double, radiusInM: Double): Result<List<Pick>>
     suspend fun createPick(pick: Pick): Result<String>
-    suspend fun deletePick(pickId: String): Result<Boolean>
+    suspend fun deletePick(pickId: String, userId: String): Result<Boolean>
 
     suspend fun fetchMyPicks(userId: String): Result<List<Pick>>
     suspend fun fetchFavoritePicks(userId: String): Result<List<Pick>>

--- a/domain/src/main/java/com/squirtles/domain/usecase/mypick/DeletePickUseCase.kt
+++ b/domain/src/main/java/com/squirtles/domain/usecase/mypick/DeletePickUseCase.kt
@@ -6,5 +6,6 @@ import javax.inject.Inject
 class DeletePickUseCase @Inject constructor(
     private val firebaseRepository: FirebaseRepository
 ) {
-    suspend operator fun invoke(pickId: String): Result<Boolean> = firebaseRepository.deletePick(pickId)
+    suspend operator fun invoke(pickId: String, userId: String): Result<Boolean> =
+        firebaseRepository.deletePick(pickId, userId)
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- resolved #148 

## 📝 작업 내용 및 코드
- 픽 삭제 시 picks뿐만 아니라  favorites와 users에서도 해당하는 정보가 삭제되도록 했습니다.

### 과정
담기, 등록된 픽 정보가 DB에 저장되면서 프로젝트의 DB 구조 상 픽 삭제를 하면 세 가지가 일어나야 했다.
- picks 컬렉션에서 삭제하려는 픽 문서 삭제
- favorites 컬렉션에서 문서의 pickId 필드 값이 삭제하려는 픽의 pickId와 같으면 해당 문서 삭제
- users 컬렉션에서 현재 유저 문서의 myPicks 필드의 배열에서 삭제하려는 픽 id 제거

삭제를 할 때는 항상 위 세 가지 작업이 함께 수행되어야 하기 때문에 세 개를 묶은 게 트랜잭션이라고 생각했다. [문서](https://firebase.google.com/docs/firestore/manage-data/transactions?hl=ko)에 따르면 트랜잭션은 클라이언트가 오프라인일 때 실패한다고 한다.

위 문서를 참고하여 트랜잭션을 사용했다. 문서의 삭제와 필드 업데이트는 삭제할 문서만 알면 간단하게 할 수 있는 것 같았다. picks와 favorites에서는 문서를 삭제해야 하고, users에서는 필드 값을 업데이트(삭제)해야 한다.

```kotlin
val 삭제할문서 = db.collection("컬렉션이름").document("문서id")

db.runTransaction { transaction ->
		transaction.delete(삭제할문서)
		
		transaction.update(필드를 업데이트 할 문서, "문서의 필드 이름", 업데이트 할 값)
}
```

삭제할 picks 문서와 업데이트 해야 할 필드가 있는 users 문서는 쉽게 가져올 수 있었다.

```kotlin
val pickDocument = db.collection(COLLECTION_PICKS).document(pickId)
val userDocument = db.collection(COLLECTION_USERS).document(userId)
```

favorites에서 삭제할 문서를 어떻게 가져와야할지 잘 몰랐다. 처음에는 단순히 `whereEqualTo("pickId", pickId).get()`으로 가져온 결과를 `transaction.delete()` 안에 넣으면 되는 거 아냐? 했는데 되지 않았다.

![image (4)](https://github.com/user-attachments/assets/6139de43-d086-45a8-8630-63a84854ac19)

![image (5)](https://github.com/user-attachments/assets/93aaf54c-722f-4f7c-b23e-fdddb062bdcf)

성공적으로 질의해서 가져온 결과는 타입이 `QuerySnapShot`이었지만, `delete()` 안에 들어갈 수 있는 타입은 `DocumentReference`였다.

이걸 보다 보니 `QuerySnapShot`, `DocumentSnapShot`, `DocumentReference`가 대체 뭔지 궁금했다.

`DocumentReference`는 Firestore에 있는 문서의 위치를 가진 객체, `DocumentSnapshot`은 Firestore에 있는 문서의 내용을 포함하고 있는 객체, `QuerySnapshot`은 query의 결과를 가지고 있으며, 0개 이상의 `DocumentSnapshot` 객체를 포함하고 있는 객체라고 이해했다.

![image (6)](https://github.com/user-attachments/assets/6de8dba6-4ff4-427f-84d8-862fe36800df)

![image (7)](https://github.com/user-attachments/assets/727704ea-2bf4-4692-8bf3-e773e88c5230)

안에서 로그를 찍어보니 favorites에서 문서의 pickId 필드 값이 삭제하려는 픽의 id와 같은 문서를 어떻게 가져올지 감이 왔다. 위의 코드에서 pickId 값은 IwPyq25rwznFp2D7nHhh이었는데, 즉 위 질의는 favorites에서 pickId 필드 값이 이와 같은 것을 찾아줘 라는 것이다.

![image (8)](https://github.com/user-attachments/assets/a7737ec4-7ef1-40dd-9f41-7d1c8e111b9b)

마지막에 찍힌 id로 시작하는 로그를 보면 그 값이 내가 찾는 문서의 id였다. 문서 id가 있으면 `db.collection(collectionId).document(documentId)` 를 DocumentReference 가져올 수 있다. 따라서 우선 favorites에서 해당하는 문서의 id를 찾고 그 id로 DocumentReference 리스트를 가져온 후에 트랜잭션으로 삭제 및 업데이트를 진행해줬다.

```kotlin
override suspend fun deletePick(pickId: String, userId: String): Boolean {
    val pickDocument = db.collection(COLLECTION_PICKS).document(pickId)
    val userDocument = db.collection(COLLECTION_USERS).document(userId)
    val favoriteDocuments = fetchFavoriteDocuments(pickId)

    return suspendCancellableCoroutine { continuation ->
        db.runTransaction { transaction ->
            transaction.delete(pickDocument)

            favoriteDocuments.forEach { document ->
                transaction.delete(document)
            }

            transaction.update(userDocument, FIELD_MY_PICKS, FieldValue.arrayRemove(pickId))
        }.addOnSuccessListener { _ ->
            continuation.resume(true)
        }.addOnFailureListener { e ->
            Log.w(TAG_LOG, "Transaction failure.", e)
            continuation.resumeWithException(e)
        }
    }
}

private suspend fun fetchFavoriteDocuments(pickId: String): List<DocumentReference> {
    return suspendCancellableCoroutine { continuation ->
        db.collection(COLLECTION_FAVORITES)
            .whereEqualTo(FIELD_PICK_ID, pickId)
            .get()
            .addOnSuccessListener { querySnapShot ->
                val documentIds = querySnapShot.documents.map { it.id }
                val documentRefs = mutableListOf<DocumentReference>()
                documentIds.forEach { id ->
                    documentRefs.add(db.collection(COLLECTION_FAVORITES).document(id))
                }
                continuation.resume(documentRefs)
            }
            .addOnFailureListener { e ->
                Log.w(TAG_LOG, "Failed to fetch favorite documents id", e)
                continuation.resumeWithException(e)
            }
    }
}
```

Firestore에서 삭제했을 때 picks, favorites 안에서 해당하는 것, users의 myPicks에서 삭제가 잘 되는 것을 확인했다.

