### PR TITLE
[refactor] 클릭한 마커가 위에 오도록

### DIFF
--- a/app/src/main/java/com/squirtles/musicroad/map/MapViewModel.kt
+++ b/app/src/main/java/com/squirtles/musicroad/map/MapViewModel.kt
@@ -178,6 +178,7 @@ class MapViewModel @Inject constructor(
         val defaultIconWidth = this.icon.getIntrinsicWidth(context)
         val defaultIconHeight = this.icon.getIntrinsicHeight(context)
 
+        zIndex = if (isClicked) CLICKED_MARKER_Z_INDEX else DEFAULT_MARKER_Z_INDEX
         this.width =
             if (isClicked) (defaultIconWidth * MARKER_SCALE).toInt() else defaultIconWidth
         this.height =

--- a/app/src/main/java/com/squirtles/musicroad/map/NaverMap.kt
+++ b/app/src/main/java/com/squirtles/musicroad/map/NaverMap.kt
@@ -265,3 +265,5 @@ private val PERMISSIONS = arrayOf(
     Manifest.permission.ACCESS_FINE_LOCATION,
     Manifest.permission.ACCESS_COARSE_LOCATION
 )
+internal const val DEFAULT_MARKER_Z_INDEX = 0
+internal const val CLICKED_MARKER_Z_INDEX = 100

--- a/app/src/main/java/com/squirtles/musicroad/map/marker/Clusterer.kt
+++ b/app/src/main/java/com/squirtles/musicroad/map/marker/Clusterer.kt
@@ -15,6 +15,7 @@ import com.naver.maps.map.overlay.Align
 import com.naver.maps.map.overlay.Marker
 import com.naver.maps.map.overlay.Overlay
 import com.naver.maps.map.overlay.OverlayImage
+import com.squirtles.musicroad.map.DEFAULT_MARKER_Z_INDEX
 import com.squirtles.musicroad.map.MapViewModel
 import com.squirtles.musicroad.map.setCameraToMarker
 import com.squirtles.musicroad.ui.theme.Black
@@ -68,6 +69,7 @@ internal fun <T : ClusteringKey> buildClusterer(
                 }
                 val clusterMarkerIconView = ClusterMarkerIconView(context, densityType)
                 marker.icon = OverlayImage.fromView(clusterMarkerIconView)
+                marker.zIndex = DEFAULT_MARKER_Z_INDEX
                 marker.anchor = PointF(0.5F, 0.5F)
                 marker.captionText = info.size.toString()
                 marker.captionColor = captionColor.toArgb()
@@ -96,6 +98,7 @@ internal fun <T : ClusteringKey> buildClusterer(
         .leafMarkerUpdater(object : DefaultLeafMarkerUpdater() {
             override fun updateLeafMarker(info: LeafMarkerInfo, marker: Marker) {
                 marker.anchor = Marker.DEFAULT_ANCHOR
+                marker.zIndex = DEFAULT_MARKER_Z_INDEX
                 marker.captionText = ""
 
                 val pick = (info.key as MarkerKey).pick


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- 없음

## 📝 작업 내용 및 코드
- 클릭한 마커가 위에 오도록 했습니다.

### 과정
사소한 것이지만 살짝 겹친 마커를 클릭했을 때 커지기만 하고 클릭한 게 앞에 오지 않고 이전 순서를 유지하는 것을 발견했다. 같은 globalZIndex를 가지는 마커가 겹치게 되면 zIndex 값이 큰 마커가 우선한다. 이를 활용해서 클릭한 상태의 마커만 zIndex 값을 높여주고 클릭되지 않은 마커는 기본 값을 가지게 하여 클릭되었을 때 클릭한 마커가 앞에 오도록 했다.

- 이전 상태

  https://github.com/user-attachments/assets/d2260cde-568e-4876-a942-ab61c039eb80

- 현재 상태

  https://github.com/user-attachments/assets/3cba7c96-6815-48c0-8133-1a6ef8a10e03


