### PR TITLE
[feature] 오버레이가 기기의 카메라에 가려지지 않도록 수정

### DIFF
--- a/app/src/main/java/com/squirtles/musicroad/videoplayer/VideoPlayerOverlay.kt
+++ b/app/src/main/java/com/squirtles/musicroad/videoplayer/VideoPlayerOverlay.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.displayCutoutPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBarsPadding
@@ -80,6 +81,7 @@ fun VideoPlayerOverlay(
             .fillMaxSize()
             .graphicsLayer { this.alpha = alpha.value }
             .background(Black.copy(alpha = alpha.value.coerceAtMost(0.5f)))
+            .displayCutoutPadding()
             .pointerInput(Unit) {
                 detectTapGestures(
                     onTap = {


### PR DESCRIPTION
## #️⃣연관된 이슈

> --

## 📝작업 내용 및 코드

### 개선 사항
화면 회전 시 뮤직비디오의 오버레이가 기기의 카메라 영역에 가려지지 않도록 수정했습니다.

|Before|After|
|-------|-----|
|<img width="320" alt="image" src="https://github.com/user-attachments/assets/3df923d5-b389-4988-9686-8641233b91da">|<img width="320" alt="image" src="https://github.com/user-attachments/assets/386f945e-8e54-49f5-a6d5-9553c62a97e5">|

카메라가 있는쪽 영역에만 패딩이 적용됩니다!

<img width="320" alt="image" src="https://github.com/user-attachments/assets/91c34a34-525d-40c3-8535-9d91da4503a2">
