### PR TITLE
[refactor] 검색 결과 클릭하여 화면 전환 시 키보드 내리기

### DIFF
--- a/app/src/main/java/com/squirtles/musicroad/create/SearchMusicScreen.kt
+++ b/app/src/main/java/com/squirtles/musicroad/create/SearchMusicScreen.kt
@@ -123,6 +123,7 @@ fun SearchMusicScreen(
                         searchResult = searchResult,
                         onItemClick = { song ->
                             createPickViewModel.onSongItemClick(song)
+                            focusManager.clearFocus()
                             onItemClick()
                         }
                     )


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- 없음

## 📝작업 내용 및 코드
- 음악 검색 결과를 클릭하고 등록 화면으로 넘어갈 때 키보드가 나중에 내려가는 게 어색해서 키보드를 내리는 코드를 추가했습니다.
- 이전

  https://github.com/user-attachments/assets/04e7fa9c-fde7-4aee-bc40-dfa8a2faefaf


- 현재

  https://github.com/user-attachments/assets/858a4159-0120-4684-9478-af358172a863

