### PR TITLE
[feature] 픽 목록 정렬 기준 추가

### DIFF
--- a/app/src/main/java/com/squirtles/musicroad/main/navigations/MainNavGraph.kt
+++ b/app/src/main/java/com/squirtles/musicroad/main/navigations/MainNavGraph.kt
@@ -18,6 +18,7 @@ import com.squirtles.musicroad.map.MapViewModel
 import com.squirtles.musicroad.media.PlayerServiceViewModel
 import com.squirtles.musicroad.pick.DetailPickScreen
 import com.squirtles.musicroad.picklist.PickListScreen
+import com.squirtles.musicroad.picklist.PickListType
 import com.squirtles.musicroad.profile.ProfileScreen
 import com.squirtles.musicroad.setting.SettingNotificationScreen
 import com.squirtles.musicroad.setting.SettingProfileScreen
@@ -54,7 +55,7 @@ fun MainNavGraph(
 
             PickListScreen(
                 userId = userId,
-                isFavoritePicks = true,
+                pickListType = PickListType.FAVORITE,
                 onBackClick = { navController.navigateUp() },
                 onItemClick = { pickId -> navigationActions.navigateToPickDetail(pickId) }
             )
@@ -68,7 +69,7 @@ fun MainNavGraph(
 
             PickListScreen(
                 userId = userId,
-                isFavoritePicks = false,
+                pickListType = PickListType.CREATED,
                 onBackClick = { navController.navigateUp() },
                 onItemClick = { pickId -> navigationActions.navigateToPickDetail(pickId) }
             )

--- a/app/src/main/java/com/squirtles/musicroad/picklist/OrderBottomSheet.kt
+++ b/app/src/main/java/com/squirtles/musicroad/picklist/OrderBottomSheet.kt
@@ -33,7 +33,7 @@ import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun SortListBottomSheet(
+fun OrderBottomSheet(
     isFavoritePicks: Boolean,
     currentOrder: Order,
     onDismissRequest: () -> Unit,

--- a/app/src/main/java/com/squirtles/musicroad/picklist/OrderBottomSheet.kt
+++ b/app/src/main/java/com/squirtles/musicroad/picklist/OrderBottomSheet.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.displayCutoutPadding
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.material.icons.Icons
@@ -13,6 +14,7 @@ import androidx.compose.material.icons.filled.Check
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
@@ -52,10 +54,11 @@ fun OrderBottomSheet(
         modifier = Modifier
             .fillMaxWidth()
             .wrapContentHeight()
-            .displayCutoutPadding(),
-        // FIXME: navigationBarsPadding을 가로모드에서만 적용하기. 세로모드일 때도 적용하면 바텀 시트가 더 올라와서 이상해보임
+            .displayCutoutPadding()
+            .navigationBarsPadding(),
         sheetState = sheetState,
         containerColor = Dark,
+        scrimColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.32f),
     ) {
         Column(
             modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/com/squirtles/musicroad/picklist/PickListScreen.kt
+++ b/app/src/main/java/com/squirtles/musicroad/picklist/PickListScreen.kt
@@ -191,6 +191,7 @@ fun PickListScreen(
     if (showSortListSheet) {
         SortListBottomSheet(
             isFavoritePicks = isFavoritePicks,
+            currentOrder = (uiState as PickListUiState.Success).order,
             onDismissRequest = { showSortListSheet = false },
             onOrderClick = { order ->
                 pickListViewModel.setListOrder(isFavoritePicks, order)

--- a/app/src/main/java/com/squirtles/musicroad/picklist/PickListScreen.kt
+++ b/app/src/main/java/com/squirtles/musicroad/picklist/PickListScreen.kt
@@ -51,7 +51,7 @@ fun PickListScreen(
     pickListViewModel: PickListViewModel = hiltViewModel()
 ) {
     val uiState by pickListViewModel.pickListUiState.collectAsStateWithLifecycle()
-    var showSortListSheet by rememberSaveable { mutableStateOf(false) }
+    var showOrderBottomSheet by rememberSaveable { mutableStateOf(false) }
 
     LaunchedEffect(Unit) {
         if (isFavoritePicks) {
@@ -111,7 +111,7 @@ fun PickListScreen(
                                 modifier = Modifier
                                     .wrapContentSize()
                                     .clip(CircleShape)
-                                    .clickable { showSortListSheet = true }
+                                    .clickable { showOrderBottomSheet = true }
                             ) {
                                 Text(
                                     text = "${
@@ -188,11 +188,11 @@ fun PickListScreen(
         }
     }
 
-    if (showSortListSheet) {
-        SortListBottomSheet(
+    if (showOrderBottomSheet) {
+        OrderBottomSheet(
             isFavoritePicks = isFavoritePicks,
             currentOrder = (uiState as PickListUiState.Success).order,
-            onDismissRequest = { showSortListSheet = false },
+            onDismissRequest = { showOrderBottomSheet = false },
             onOrderClick = { order ->
                 pickListViewModel.setListOrder(isFavoritePicks, order)
             },

--- a/app/src/main/java/com/squirtles/musicroad/picklist/PickListScreen.kt
+++ b/app/src/main/java/com/squirtles/musicroad/picklist/PickListScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.wear.compose.material.CircularProgressIndicator
+import com.squirtles.domain.model.Order
 import com.squirtles.musicroad.R
 import com.squirtles.musicroad.common.Constants.COLOR_STOPS
 import com.squirtles.musicroad.common.Constants.DEFAULT_PADDING
@@ -191,7 +192,9 @@ fun PickListScreen(
         SortListBottomSheet(
             isFavoritePicks = isFavoritePicks,
             onDismissRequest = { showSortListSheet = false },
-            onOrderClick = { order -> pickListViewModel.setListOrder(order) },
+            onOrderClick = { order ->
+                pickListViewModel.setListOrder(isFavoritePicks, order)
+            },
         )
     }
 }

--- a/app/src/main/java/com/squirtles/musicroad/picklist/PickListScreen.kt
+++ b/app/src/main/java/com/squirtles/musicroad/picklist/PickListScreen.kt
@@ -1,11 +1,13 @@
 package com.squirtles.musicroad.picklist
 
+import android.content.res.Configuration
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.displayCutoutPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -27,6 +29,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -50,6 +53,7 @@ fun PickListScreen(
     onItemClick: (String) -> Unit,
     pickListViewModel: PickListViewModel = hiltViewModel()
 ) {
+    val isLandscape = LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE
     val uiState by pickListViewModel.pickListUiState.collectAsStateWithLifecycle()
     var showOrderBottomSheet by rememberSaveable { mutableStateOf(false) }
 
@@ -76,7 +80,7 @@ fun PickListScreen(
                 .fillMaxSize()
                 .background(Brush.verticalGradient(colorStops = COLOR_STOPS))
                 .padding(innerPadding)
-//                .displayCutoutPadding() // FIXME: 가로모드에서만 적용하기. 아니면 세로모드일 때 이만큼 목록이 내려옴
+                .then(if (isLandscape) Modifier.displayCutoutPadding() else Modifier)
         ) {
             when (uiState) {
                 PickListUiState.Loading -> {

--- a/app/src/main/java/com/squirtles/musicroad/picklist/PickListType.kt
+++ b/app/src/main/java/com/squirtles/musicroad/picklist/PickListType.kt
@@ -1,0 +1,5 @@
+package com.squirtles.musicroad.picklist
+
+enum class PickListType {
+    FAVORITE, CREATED
+}

--- a/app/src/main/java/com/squirtles/musicroad/picklist/PickListUiState.kt
+++ b/app/src/main/java/com/squirtles/musicroad/picklist/PickListUiState.kt
@@ -1,12 +1,7 @@
 package com.squirtles.musicroad.picklist
 
+import com.squirtles.domain.model.Order
 import com.squirtles.domain.model.Pick
-
-enum class Order {
-    LATEST,
-    OLDEST,
-    FAVORITE_DESC,
-}
 
 sealed class PickListUiState {
     data object Loading : PickListUiState()

--- a/app/src/main/java/com/squirtles/musicroad/picklist/PickListUiState.kt
+++ b/app/src/main/java/com/squirtles/musicroad/picklist/PickListUiState.kt
@@ -2,8 +2,14 @@ package com.squirtles.musicroad.picklist
 
 import com.squirtles.domain.model.Pick
 
+enum class Order {
+    LATEST,
+    OLDEST,
+    FAVORITE_DESC,
+}
+
 sealed class PickListUiState {
-    data object Loading: PickListUiState()
-    data class Success(val pickList: List<Pick>) : PickListUiState()
+    data object Loading : PickListUiState()
+    data class Success(val pickList: List<Pick>, val order: Order) : PickListUiState()
     data object Error : PickListUiState()
 }

--- a/app/src/main/java/com/squirtles/musicroad/picklist/PickListViewModel.kt
+++ b/app/src/main/java/com/squirtles/musicroad/picklist/PickListViewModel.kt
@@ -70,25 +70,19 @@ class PickListViewModel @Inject constructor(
 
     private fun setList(order: Order) {
         defaultList?.let { pickList ->
-            when (order) {
-                Order.LATEST ->
-                    _pickListUiState.value = PickListUiState.Success(
-                        pickList = pickList,
-                        order = order
-                    )
+            val sortedList = when (order) {
+                Order.LATEST -> pickList
 
-                Order.OLDEST ->
-                    _pickListUiState.value = PickListUiState.Success(
-                        pickList = pickList.reversed(),
-                        order = order
-                    )
+                Order.OLDEST -> pickList.reversed()
 
                 Order.FAVORITE_DESC ->
-                    _pickListUiState.value = PickListUiState.Success(
-                        pickList = pickList.sortedByDescending { it.favoriteCount },
-                        order = order
-                    )
+                    pickList.sortedByDescending { it.favoriteCount }
             }
+
+            _pickListUiState.value = PickListUiState.Success(
+                pickList = sortedList,
+                order = order
+            )
         }
     }
 }

--- a/app/src/main/java/com/squirtles/musicroad/picklist/PickListViewModel.kt
+++ b/app/src/main/java/com/squirtles/musicroad/picklist/PickListViewModel.kt
@@ -57,12 +57,11 @@ class PickListViewModel @Inject constructor(
         }
     }
 
-    fun setListOrder(isFavoritePicks: Boolean, order: Order) {
+    fun setListOrder(type: PickListType, order: Order) {
         viewModelScope.launch {
-            if (isFavoritePicks) {
-                saveFavoriteListOrderUseCase(order)
-            } else {
-                saveMyListOrderUseCase(order)
+            when (type) {
+                PickListType.FAVORITE -> saveFavoriteListOrderUseCase(order)
+                PickListType.CREATED -> saveMyListOrderUseCase(order)
             }
             setList(order)
         }

--- a/app/src/main/java/com/squirtles/musicroad/picklist/SortListBottomSheet.kt
+++ b/app/src/main/java/com/squirtles/musicroad/picklist/SortListBottomSheet.kt
@@ -1,0 +1,104 @@
+package com.squirtles.musicroad.picklist
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.displayCutoutPadding
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import com.squirtles.musicroad.R
+import com.squirtles.musicroad.common.Constants.DEFAULT_PADDING
+import com.squirtles.musicroad.ui.theme.Dark
+import com.squirtles.musicroad.ui.theme.White
+import kotlinx.coroutines.launch
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SortListBottomSheet(
+    isFavoritePicks: Boolean,
+    onDismissRequest: () -> Unit,
+    onOrderClick: (Order) -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState()
+    val scope = rememberCoroutineScope()
+    val orderList = listOf(
+        stringResource(if (isFavoritePicks) R.string.latest_favorite_order else R.string.latest_create_order) to Order.LATEST,
+        stringResource(if (isFavoritePicks) R.string.oldest_favorite_order else R.string.oldest_create_order) to Order.OLDEST,
+        stringResource(R.string.favorite_count_desc) to Order.FAVORITE_DESC,
+    )
+
+    ModalBottomSheet(
+        onDismissRequest = onDismissRequest,
+        modifier = Modifier
+            .fillMaxWidth()
+            .wrapContentHeight()
+            .displayCutoutPadding(),
+        // FIXME: navigationBarsPadding을 가로모드에서만 적용하기. 세로모드일 때도 적용하면 바텀 시트가 더 올라와서 이상해보임
+        sheetState = sheetState,
+        containerColor = Dark,
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            orderList.forEach { (orderText, order) ->
+                BottomSheetMenu(
+                    text = orderText
+                ) {
+                    scope
+                        .launch {
+                            onOrderClick(order)
+                            sheetState.hide()
+                        }
+                        .invokeOnCompletion {
+                            if (!sheetState.isVisible) {
+                                onDismissRequest()
+                            }
+                        }
+                }
+            }
+
+            HorizontalDivider(color = White)
+            BottomSheetMenu(
+                text = stringResource(R.string.close_button_text),
+                textAlign = TextAlign.Center,
+            ) {
+                scope
+                    .launch { sheetState.hide() }
+                    .invokeOnCompletion {
+                        if (!sheetState.isVisible) {
+                            onDismissRequest()
+                        }
+                    }
+            }
+        }
+    }
+}
+
+@Composable
+private fun BottomSheetMenu(
+    text: String,
+    textAlign: TextAlign = TextAlign.Start,
+    onClick: () -> Unit,
+) {
+    Text(
+        text = text,
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onClick() }
+            .padding(DEFAULT_PADDING),
+        color = White,
+        textAlign = textAlign,
+    )
+}

--- a/app/src/main/java/com/squirtles/musicroad/picklist/SortListBottomSheet.kt
+++ b/app/src/main/java/com/squirtles/musicroad/picklist/SortListBottomSheet.kt
@@ -1,13 +1,18 @@
 package com.squirtles.musicroad.picklist
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.displayCutoutPadding
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
@@ -16,11 +21,13 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import com.squirtles.domain.model.Order
 import com.squirtles.musicroad.R
 import com.squirtles.musicroad.common.Constants.DEFAULT_PADDING
 import com.squirtles.musicroad.ui.theme.Dark
+import com.squirtles.musicroad.ui.theme.Primary
 import com.squirtles.musicroad.ui.theme.White
 import kotlinx.coroutines.launch
 
@@ -28,6 +35,7 @@ import kotlinx.coroutines.launch
 @Composable
 fun SortListBottomSheet(
     isFavoritePicks: Boolean,
+    currentOrder: Order,
     onDismissRequest: () -> Unit,
     onOrderClick: (Order) -> Unit,
 ) {
@@ -55,11 +63,14 @@ fun SortListBottomSheet(
         ) {
             orderList.forEach { (orderText, order) ->
                 BottomSheetMenu(
-                    text = orderText
+                    text = orderText,
+                    isSelected = currentOrder == order,
                 ) {
                     scope
                         .launch {
-                            onOrderClick(order)
+                            if (currentOrder != order) {
+                                onOrderClick(order)
+                            }
                             sheetState.hide()
                         }
                         .invokeOnCompletion {
@@ -91,15 +102,31 @@ fun SortListBottomSheet(
 private fun BottomSheetMenu(
     text: String,
     textAlign: TextAlign = TextAlign.Start,
+    isSelected: Boolean = false,
     onClick: () -> Unit,
 ) {
-    Text(
-        text = text,
+    Row(
         modifier = Modifier
             .fillMaxWidth()
             .clickable { onClick() }
             .padding(DEFAULT_PADDING),
-        color = White,
-        textAlign = textAlign,
-    )
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = text,
+            modifier = Modifier.weight(1f),
+            color = if (isSelected) Primary else White,
+            fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal,
+            textAlign = textAlign,
+        )
+
+        if (isSelected) {
+            Icon(
+                imageVector = Icons.Default.Check,
+                contentDescription = stringResource(R.string.selected_icon_description),
+                tint = Primary
+            )
+        }
+    }
 }

--- a/app/src/main/java/com/squirtles/musicroad/picklist/SortListBottomSheet.kt
+++ b/app/src/main/java/com/squirtles/musicroad/picklist/SortListBottomSheet.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
+import com.squirtles.domain.model.Order
 import com.squirtles.musicroad.R
 import com.squirtles.musicroad.common.Constants.DEFAULT_PADDING
 import com.squirtles.musicroad.ui.theme.Dark

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -49,8 +49,14 @@
     <string name="favorite_picks_empty">담은 픽이 없습니다</string>
     <string name="my_picks_empty">등록한 픽이 없습니다</string>
     <string name="error_loading_pick_list">일시적인 오류가 발생했습니다.</string>
+
+    <!-- Pick List Order -->
     <string name="latest_create_order">최근 등록순</string>
     <string name="latest_favorite_order">최근 담은순</string>
+    <string name="oldest_favorite_order">과거 담은순</string>
+    <string name="oldest_create_order">과거 등록순</string>
+    <string name="favorite_count_desc">담기 많은순</string>
+    <string name="close_button_text">닫기</string>
 
     <!-- Search Music -->
     <string name="search">검색</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -56,6 +56,7 @@
     <string name="oldest_favorite_order">과거 담은순</string>
     <string name="oldest_create_order">과거 등록순</string>
     <string name="favorite_count_desc">담기 많은순</string>
+    <string name="selected_icon_description">체크 아이콘</string>
     <string name="close_button_text">닫기</string>
 
     <!-- Search Music -->

--- a/data/src/main/java/com/squirtles/data/datasource/local/LocalDataSourceImpl.kt
+++ b/data/src/main/java/com/squirtles/data/datasource/local/LocalDataSourceImpl.kt
@@ -6,6 +6,7 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import com.squirtles.domain.datasource.LocalDataSource
+import com.squirtles.domain.model.Order
 import com.squirtles.domain.model.User
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -25,6 +26,12 @@ class LocalDataSourceImpl @Inject constructor(
 
     private var _currentLocation: MutableStateFlow<Location?> = MutableStateFlow(null)
     override val lastLocation: StateFlow<Location?> = _currentLocation.asStateFlow()
+
+    private var _favoriteListOrder = Order.LATEST
+    override val favoriteListOrder get() = _favoriteListOrder
+
+    private var _myListOrder = Order.LATEST
+    override val myListOrder get() = _myListOrder
 
     override fun readUserId(): Flow<String?> {
         val dataStoreKey = stringPreferencesKey(USER_ID_KEY)
@@ -46,6 +53,14 @@ class LocalDataSourceImpl @Inject constructor(
 
     override suspend fun saveCurrentLocation(location: Location) {
         _currentLocation.emit(location)
+    }
+
+    override suspend fun saveFavoriteListOrder(order: Order) {
+        _favoriteListOrder = order
+    }
+
+    override suspend fun saveMyListOrder(order: Order) {
+        _myListOrder = order
     }
 
     companion object {

--- a/data/src/main/java/com/squirtles/data/repository/LocalRepositoryImpl.kt
+++ b/data/src/main/java/com/squirtles/data/repository/LocalRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.squirtles.data.repository
 
 import android.location.Location
 import com.squirtles.domain.datasource.LocalDataSource
+import com.squirtles.domain.model.Order
 import com.squirtles.domain.model.User
 import com.squirtles.domain.repository.LocalRepository
 import javax.inject.Inject
@@ -12,6 +13,8 @@ class LocalRepositoryImpl @Inject constructor(
     override val userId get() = localDataSource.readUserId()
     override val currentUser get() = localDataSource.currentUser
     override val lastLocation get() = localDataSource.lastLocation
+    override val favoriteListOrder get() = localDataSource.favoriteListOrder
+    override val myListOrder get() = localDataSource.myListOrder
 
     override suspend fun saveUserId(userId: String) {
         localDataSource.saveUserId(userId)
@@ -23,5 +26,13 @@ class LocalRepositoryImpl @Inject constructor(
 
     override suspend fun saveCurrentLocation(location: Location) {
         localDataSource.saveCurrentLocation(location)
+    }
+
+    override suspend fun saveFavoriteListOrder(order: Order) {
+        localDataSource.saveFavoriteListOrder(order)
+    }
+
+    override suspend fun saveMyListOrder(order: Order) {
+        localDataSource.saveMyListOrder(order)
     }
 }

--- a/domain/src/main/java/com/squirtles/domain/datasource/LocalDataSource.kt
+++ b/domain/src/main/java/com/squirtles/domain/datasource/LocalDataSource.kt
@@ -1,6 +1,7 @@
 package com.squirtles.domain.datasource
 
 import android.location.Location
+import com.squirtles.domain.model.Order
 import com.squirtles.domain.model.User
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
@@ -8,9 +9,13 @@ import kotlinx.coroutines.flow.StateFlow
 interface LocalDataSource {
     val currentUser: User
     val lastLocation: StateFlow<Location?>
+    val favoriteListOrder: Order
+    val myListOrder: Order
 
     fun readUserId(): Flow<String?>
     suspend fun saveUserId(userId: String)
     suspend fun saveCurrentUser(user: User)
     suspend fun saveCurrentLocation(location: Location)
+    suspend fun saveFavoriteListOrder(order: Order)
+    suspend fun saveMyListOrder(order: Order)
 }

--- a/domain/src/main/java/com/squirtles/domain/model/Order.kt
+++ b/domain/src/main/java/com/squirtles/domain/model/Order.kt
@@ -1,0 +1,7 @@
+package com.squirtles.domain.model
+
+enum class Order {
+    LATEST,
+    OLDEST,
+    FAVORITE_DESC,
+}

--- a/domain/src/main/java/com/squirtles/domain/repository/LocalRepository.kt
+++ b/domain/src/main/java/com/squirtles/domain/repository/LocalRepository.kt
@@ -1,6 +1,7 @@
 package com.squirtles.domain.repository
 
 import android.location.Location
+import com.squirtles.domain.model.Order
 import com.squirtles.domain.model.User
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
@@ -9,8 +10,12 @@ interface LocalRepository {
     val userId: Flow<String?> // 기기에 저장된 userId
     val currentUser: User
     val lastLocation: StateFlow<Location?>
+    val favoriteListOrder: Order // 픽 보관함 정렬 순서
+    val myListOrder: Order // 등록한 픽 정렬 순서
 
     suspend fun saveUserId(userId: String)
     suspend fun saveCurrentUser(user: User)
     suspend fun saveCurrentLocation(location: Location)
+    suspend fun saveFavoriteListOrder(order: Order)
+    suspend fun saveMyListOrder(order: Order)
 }

--- a/domain/src/main/java/com/squirtles/domain/usecase/local/GetFavoriteListOrderUseCase.kt
+++ b/domain/src/main/java/com/squirtles/domain/usecase/local/GetFavoriteListOrderUseCase.kt
@@ -1,0 +1,10 @@
+package com.squirtles.domain.usecase.local
+
+import com.squirtles.domain.repository.LocalRepository
+import javax.inject.Inject
+
+class GetFavoriteListOrderUseCase @Inject constructor(
+    private val localRepository: LocalRepository
+) {
+    operator fun invoke() = localRepository.favoriteListOrder
+}

--- a/domain/src/main/java/com/squirtles/domain/usecase/local/GetMyListOrderUseCase.kt
+++ b/domain/src/main/java/com/squirtles/domain/usecase/local/GetMyListOrderUseCase.kt
@@ -1,0 +1,10 @@
+package com.squirtles.domain.usecase.local
+
+import com.squirtles.domain.repository.LocalRepository
+import javax.inject.Inject
+
+class GetMyListOrderUseCase @Inject constructor(
+    private val localRepository: LocalRepository
+) {
+    operator fun invoke() = localRepository.myListOrder
+}

--- a/domain/src/main/java/com/squirtles/domain/usecase/local/SaveFavoriteListOrderUseCase.kt
+++ b/domain/src/main/java/com/squirtles/domain/usecase/local/SaveFavoriteListOrderUseCase.kt
@@ -1,0 +1,11 @@
+package com.squirtles.domain.usecase.local
+
+import com.squirtles.domain.model.Order
+import com.squirtles.domain.repository.LocalRepository
+import javax.inject.Inject
+
+class SaveFavoriteListOrderUseCase @Inject constructor(
+    private val localRepository: LocalRepository
+) {
+    suspend operator fun invoke(order: Order) = localRepository.saveFavoriteListOrder(order)
+}

--- a/domain/src/main/java/com/squirtles/domain/usecase/local/SaveMyListOrderUseCase.kt
+++ b/domain/src/main/java/com/squirtles/domain/usecase/local/SaveMyListOrderUseCase.kt
@@ -1,0 +1,11 @@
+package com.squirtles.domain.usecase.local
+
+import com.squirtles.domain.model.Order
+import com.squirtles.domain.repository.LocalRepository
+import javax.inject.Inject
+
+class SaveMyListOrderUseCase @Inject constructor(
+    private val localRepository: LocalRepository
+) {
+    suspend operator fun invoke(order: Order) = localRepository.saveMyListOrder(order)
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- resolved #159 

## 📝 작업 내용 및 코드
- 픽 보관함/등록한 픽을 최근 담은순/등록순, 과거 담은순/등록순, 담기 많은순으로 정렬할 수 있도록 정렬 기준을 추가했습니다.

  https://github.com/user-attachments/assets/fec846b3-e40c-41c2-b84c-6a7c3deccb8a

[구현 과정](https://vaulted-system-3ae.notion.site/15af85098cd58095b1a2ca94009832c5)

## 💬 리뷰 요구사항
> PR 올려야지 한지가 좀 된 것 같은데 드디어 올리네요 ㅎㅎ..

- 최근 담은순/등록순, 과거 담은순/등록순, 담기 많은순 외에 뭔가 더 있었으면 하는 정렬 기준이 있다면 추천해주셔도 좋을 것 같습니당
- LocalDataSource에 정렬 기준을 각각 저장하면서 usecase가 많아졌는데 어쩔 수 없는 거겠죠..?