### PR TITLE
[feature] 픽 목록 편집 모드

### DIFF
--- a/app/src/main/java/com/squirtles/musicroad/common/AlertStringDialog.kt
+++ b/app/src/main/java/com/squirtles/musicroad/common/AlertStringDialog.kt
@@ -1,8 +1,9 @@
-package com.squirtles.musicroad.pick.components
+package com.squirtles.musicroad.common
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -22,8 +23,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.squirtles.musicroad.R
-import com.squirtles.musicroad.common.VerticalSpacer
-import com.squirtles.musicroad.common.HorizontalSpacer
 import com.squirtles.musicroad.ui.theme.Black
 import com.squirtles.musicroad.ui.theme.MusicRoadTheme
 import com.squirtles.musicroad.ui.theme.Primary
@@ -31,9 +30,11 @@ import com.squirtles.musicroad.ui.theme.White
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun DeletePickDialog(
+internal fun AlertStringDialog(
     onDismissRequest: () -> Unit,
-    onDeletion: () -> Unit
+    title: String,
+    body: String,
+    buttons: @Composable RowScope.() -> Unit,
 ) {
     BasicAlertDialog(
         onDismissRequest = { onDismissRequest() },
@@ -48,7 +49,7 @@ fun DeletePickDialog(
                 verticalArrangement = Arrangement.Center
             ) {
                 Text(
-                    text = stringResource(R.string.delete_pick_dialog_title),
+                    text = title,
                     color = Black,
                     fontWeight = FontWeight.Bold,
                     style = MaterialTheme.typography.bodyLarge
@@ -57,7 +58,7 @@ fun DeletePickDialog(
                 VerticalSpacer(8)
 
                 Text(
-                    text = stringResource(R.string.delete_pick_dialog_body),
+                    text = body,
                     color = Black,
                     style = MaterialTheme.typography.bodyLarge
                 )
@@ -67,45 +68,59 @@ fun DeletePickDialog(
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.End,
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    TextButton(
-                        onClick = { onDismissRequest() },
-                        colors = ButtonDefaults.buttonColors().copy(
-                            containerColor = Color.Transparent,
-                            contentColor = Black
-                        )
-                    ) {
-                        Text(stringResource(R.string.delete_pick_dialog_cancel))
-                    }
-
-                    HorizontalSpacer(8)
-
-                    TextButton(
-                        onClick = { onDeletion() },
-                        colors = ButtonDefaults.buttonColors().copy(
-                            containerColor = Color.Transparent,
-                            contentColor = Primary
-                        )
-                    ) {
-                        Text(
-                            text = stringResource(R.string.delete_pick_dialog_delete),
-                            fontWeight = FontWeight.Bold
-                        )
-                    }
-                }
+                    verticalAlignment = Alignment.CenterVertically,
+                    content = buttons
+                )
             }
         }
     }
 }
 
+@Composable
+internal fun DialogTextButton(
+    onClick: () -> Unit,
+    text: String,
+    textColor: Color = Black,
+    buttonColor: Color = Color.Transparent,
+    fontWeight: FontWeight? = null,
+) {
+    TextButton(
+        onClick = onClick,
+        colors = ButtonDefaults.buttonColors().copy(
+            containerColor = buttonColor,
+            contentColor = textColor
+        )
+    ) {
+        Text(
+            text = text,
+            fontWeight = fontWeight,
+        )
+    }
+}
+
 @Preview(showBackground = true)
 @Composable
-fun DeletePickDialogPreview() {
+private fun DeletePickDialogPreview() {
     MusicRoadTheme {
-        DeletePickDialog(
+        AlertStringDialog(
             onDismissRequest = {},
-            onDeletion = {}
+            title = stringResource(R.string.delete_pick_dialog_title),
+            body = stringResource(R.string.delete_pick_dialog_body),
+            buttons = {
+                DialogTextButton(
+                    onClick = {},
+                    text = "취소"
+                )
+
+                HorizontalSpacer(8)
+
+                DialogTextButton(
+                    onClick = {},
+                    text = "삭제하기",
+                    textColor = Primary,
+                    fontWeight = FontWeight.Bold
+                )
+            }
         )
     }
 }

--- a/app/src/main/java/com/squirtles/musicroad/common/DefaultTopAppBar.kt
+++ b/app/src/main/java/com/squirtles/musicroad/common/DefaultTopAppBar.kt
@@ -1,5 +1,7 @@
 package com.squirtles.musicroad.common
 
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.displayCutoutPadding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.CenterAlignedTopAppBar
@@ -10,6 +12,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
@@ -23,6 +26,7 @@ fun DefaultTopAppBar(
     title: String,
     titleStyle: TextStyle = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
     onBackClick: () -> Unit,
+    actions: @Composable RowScope.() -> Unit = {},
 ) {
     CenterAlignedTopAppBar(
         title = {
@@ -31,6 +35,7 @@ fun DefaultTopAppBar(
                 style = titleStyle
             )
         },
+        modifier = Modifier.displayCutoutPadding(),
         navigationIcon = {
             IconButton(
                 onClick = onBackClick
@@ -42,6 +47,7 @@ fun DefaultTopAppBar(
                 )
             }
         },
+        actions = actions,
         colors = TopAppBarDefaults.centerAlignedTopAppBarColors().copy(
             containerColor = Color.Transparent,
             titleContentColor = White

--- a/app/src/main/java/com/squirtles/musicroad/common/MessageAlertDialog.kt
+++ b/app/src/main/java/com/squirtles/musicroad/common/MessageAlertDialog.kt
@@ -30,7 +30,7 @@ import com.squirtles.musicroad.ui.theme.White
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-internal fun AlertStringDialog(
+internal fun MessageAlertDialog(
     onDismissRequest: () -> Unit,
     title: String,
     body: String,
@@ -102,7 +102,7 @@ internal fun DialogTextButton(
 @Composable
 private fun DeletePickDialogPreview() {
     MusicRoadTheme {
-        AlertStringDialog(
+        MessageAlertDialog(
             onDismissRequest = {},
             title = stringResource(R.string.delete_pick_dialog_title),
             body = stringResource(R.string.delete_pick_dialog_body),

--- a/app/src/main/java/com/squirtles/musicroad/common/PickInfoText.kt
+++ b/app/src/main/java/com/squirtles/musicroad/common/PickInfoText.kt
@@ -71,6 +71,7 @@ fun CommentText(
 @Composable
 fun TotalCountText(
     modifier: Modifier = Modifier,
+    prefixText: String = stringResource(R.string.total_count_text),
     totalCount: Int,
     defaultColor: Color = MaterialTheme.colorScheme.onSurface,
     pointColor: Color = MaterialTheme.colorScheme.primary,
@@ -84,7 +85,7 @@ fun TotalCountText(
                     fontWeight = FontWeight.Bold
                 )
             ) {
-                append("전체 ")
+                append("$prefixText ")
             }
             withStyle(
                 SpanStyle(

--- a/app/src/main/java/com/squirtles/musicroad/common/PickInfoText.kt
+++ b/app/src/main/java/com/squirtles/musicroad/common/PickInfoText.kt
@@ -69,10 +69,10 @@ fun CommentText(
 }
 
 @Composable
-fun TotalCountText(
-    modifier: Modifier = Modifier,
-    prefixText: String = stringResource(R.string.total_count_text),
+fun CountText(
     totalCount: Int,
+    modifier: Modifier = Modifier,
+    countLabel: String = stringResource(R.string.total_count_text),
     defaultColor: Color = MaterialTheme.colorScheme.onSurface,
     pointColor: Color = MaterialTheme.colorScheme.primary,
     style: TextStyle = MaterialTheme.typography.titleMedium
@@ -85,7 +85,7 @@ fun TotalCountText(
                     fontWeight = FontWeight.Bold
                 )
             ) {
-                append("$prefixText ")
+                append("$countLabel ")
             }
             withStyle(
                 SpanStyle(

--- a/app/src/main/java/com/squirtles/musicroad/map/components/ClusterBottomSheet.kt
+++ b/app/src/main/java/com/squirtles/musicroad/map/components/ClusterBottomSheet.kt
@@ -28,12 +28,12 @@ import com.squirtles.musicroad.common.AlbumImage
 import com.squirtles.musicroad.common.CommentText
 import com.squirtles.musicroad.common.Constants.DEFAULT_PADDING
 import com.squirtles.musicroad.common.Constants.REQUEST_IMAGE_SIZE_DEFAULT
+import com.squirtles.musicroad.common.CountText
 import com.squirtles.musicroad.common.CreatedByOtherUserText
 import com.squirtles.musicroad.common.CreatedBySelfText
 import com.squirtles.musicroad.common.FavoriteCountText
-import com.squirtles.musicroad.common.SongInfoText
-import com.squirtles.musicroad.common.TotalCountText
 import com.squirtles.musicroad.common.HorizontalSpacer
+import com.squirtles.musicroad.common.SongInfoText
 import com.squirtles.musicroad.common.VerticalSpacer
 import kotlinx.coroutines.launch
 
@@ -57,11 +57,11 @@ fun ClusterBottomSheet(
         containerColor = MaterialTheme.colorScheme.surface
     ) {
         clusterPickList?.let { pickList ->
-            TotalCountText(
+            CountText(
+                totalCount = pickList.size,
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(start = DEFAULT_PADDING),
-                totalCount = pickList.size
+                    .padding(start = DEFAULT_PADDING)
             )
             
             VerticalSpacer(height = 8)

--- a/app/src/main/java/com/squirtles/musicroad/pick/DetailPickScreen.kt
+++ b/app/src/main/java/com/squirtles/musicroad/pick/DetailPickScreen.kt
@@ -55,9 +55,9 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.flowWithLifecycle
 import com.squirtles.domain.model.Pick
 import com.squirtles.musicroad.R
-import com.squirtles.musicroad.common.AlertStringDialog
 import com.squirtles.musicroad.common.DialogTextButton
 import com.squirtles.musicroad.common.HorizontalSpacer
+import com.squirtles.musicroad.common.MessageAlertDialog
 import com.squirtles.musicroad.common.VerticalSpacer
 import com.squirtles.musicroad.media.PlayerServiceViewModel
 import com.squirtles.musicroad.pick.PickViewModel.Companion.DEFAULT_PICK
@@ -277,7 +277,7 @@ fun DetailPickScreen(
     }
 
     if (showDeletePickDialog) {
-        AlertStringDialog(
+        MessageAlertDialog(
             onDismissRequest = {
                 showDeletePickDialog = false
             },

--- a/app/src/main/java/com/squirtles/musicroad/pick/DetailPickScreen.kt
+++ b/app/src/main/java/com/squirtles/musicroad/pick/DetailPickScreen.kt
@@ -41,6 +41,8 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.lerp
@@ -53,12 +55,14 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.flowWithLifecycle
 import com.squirtles.domain.model.Pick
 import com.squirtles.musicroad.R
+import com.squirtles.musicroad.common.AlertStringDialog
+import com.squirtles.musicroad.common.DialogTextButton
+import com.squirtles.musicroad.common.HorizontalSpacer
 import com.squirtles.musicroad.common.VerticalSpacer
 import com.squirtles.musicroad.media.PlayerServiceViewModel
 import com.squirtles.musicroad.pick.PickViewModel.Companion.DEFAULT_PICK
 import com.squirtles.musicroad.pick.components.CircleAlbumCover
 import com.squirtles.musicroad.pick.components.CommentText
-import com.squirtles.musicroad.pick.components.DeletePickDialog
 import com.squirtles.musicroad.pick.components.DetailPickTopAppBar
 import com.squirtles.musicroad.pick.components.MusicVideoKnob
 import com.squirtles.musicroad.pick.components.PickInformation
@@ -66,6 +70,7 @@ import com.squirtles.musicroad.pick.components.SongInfo
 import com.squirtles.musicroad.pick.components.music.MusicPlayer
 import com.squirtles.musicroad.pick.components.music.visualizer.BaseVisualizer
 import com.squirtles.musicroad.ui.theme.Black
+import com.squirtles.musicroad.ui.theme.Primary
 import com.squirtles.musicroad.ui.theme.White
 import com.squirtles.musicroad.videoplayer.MusicVideoScreen
 import kotlinx.coroutines.launch
@@ -272,14 +277,32 @@ fun DetailPickScreen(
     }
 
     if (showDeletePickDialog) {
-        DeletePickDialog(
+        AlertStringDialog(
             onDismissRequest = {
                 showDeletePickDialog = false
             },
-            onDeletion = {
-                showDeletePickDialog = false
-                pickViewModel.deletePick(pickId)
-            }
+            title = stringResource(R.string.delete_pick_dialog_title),
+            body = stringResource(R.string.delete_pick_dialog_body),
+            buttons = {
+                DialogTextButton(
+                    onClick = {
+                        showDeletePickDialog = false
+                    },
+                    text = stringResource(R.string.delete_pick_dialog_cancel)
+                )
+
+                HorizontalSpacer(8)
+
+                DialogTextButton(
+                    onClick = {
+                        showDeletePickDialog = false
+                        pickViewModel.deletePick(pickId)
+                    },
+                    text = stringResource(R.string.delete_pick_dialog_delete),
+                    textColor = Primary,
+                    fontWeight = FontWeight.Bold
+                )
+            },
         )
     }
 

--- a/app/src/main/java/com/squirtles/musicroad/picklist/DeleteSelectedPickDialog.kt
+++ b/app/src/main/java/com/squirtles/musicroad/picklist/DeleteSelectedPickDialog.kt
@@ -25,7 +25,7 @@ internal fun DeleteSelectedPickDialog(
             stringResource(
                 when (pickListType) {
                     PickListType.FAVORITE -> R.string.delete_selected_favorite_pick_dialog_body
-                    PickListType.CREATED -> R.string.delete_pick_dialog_body
+                    PickListType.CREATED -> R.string.delete_selected_pick_dialog_body
                 },
                 selectedPickCount
             )

--- a/app/src/main/java/com/squirtles/musicroad/picklist/DeleteSelectedPickDialog.kt
+++ b/app/src/main/java/com/squirtles/musicroad/picklist/DeleteSelectedPickDialog.kt
@@ -1,0 +1,56 @@
+package com.squirtles.musicroad.picklist
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import com.squirtles.musicroad.R
+import com.squirtles.musicroad.common.AlertStringDialog
+import com.squirtles.musicroad.common.DialogTextButton
+import com.squirtles.musicroad.common.HorizontalSpacer
+import com.squirtles.musicroad.ui.theme.Primary
+
+@Composable
+internal fun DeleteSelectedPickDialog(
+    selectedPickCount: Int,
+    pickListType: PickListType,
+    onDismissRequest: () -> Unit,
+    onDeletePickClick: () -> Unit,
+) {
+    AlertStringDialog(
+        onDismissRequest = onDismissRequest,
+        title = stringResource(if (selectedPickCount == 0) R.string.default_alert_dialog_title else R.string.delete_pick_dialog_title),
+        body = if (selectedPickCount == 0) {
+            stringResource(R.string.no_selected_pick_dialog_body)
+        } else {
+            stringResource(
+                when (pickListType) {
+                    PickListType.FAVORITE -> R.string.delete_selected_favorite_pick_dialog_body
+                    PickListType.CREATED -> R.string.delete_pick_dialog_body
+                },
+                selectedPickCount
+            )
+        },
+        buttons = {
+            if (selectedPickCount == 0) {
+                DialogTextButton(
+                    onClick = onDismissRequest,
+                    text = stringResource(R.string.confirm_text)
+                )
+            } else {
+                DialogTextButton(
+                    onClick = onDismissRequest,
+                    text = stringResource(R.string.delete_pick_dialog_cancel)
+                )
+
+                HorizontalSpacer(8)
+
+                DialogTextButton(
+                    onClick = onDeletePickClick,
+                    text = stringResource(R.string.delete_pick_dialog_delete),
+                    textColor = Primary,
+                    fontWeight = FontWeight.Bold
+                )
+            }
+        },
+    )
+}

--- a/app/src/main/java/com/squirtles/musicroad/picklist/DeleteSelectedPickDialog.kt
+++ b/app/src/main/java/com/squirtles/musicroad/picklist/DeleteSelectedPickDialog.kt
@@ -18,39 +18,28 @@ internal fun DeleteSelectedPickDialog(
 ) {
     MessageAlertDialog(
         onDismissRequest = onDismissRequest,
-        title = stringResource(if (selectedPickCount == 0) R.string.default_alert_dialog_title else R.string.delete_pick_dialog_title),
-        body = if (selectedPickCount == 0) {
-            stringResource(R.string.no_selected_pick_dialog_body)
-        } else {
-            stringResource(
-                when (pickListType) {
-                    PickListType.FAVORITE -> R.string.delete_selected_favorite_pick_dialog_body
-                    PickListType.CREATED -> R.string.delete_selected_pick_dialog_body
-                },
-                selectedPickCount
-            )
-        },
+        title = stringResource(R.string.delete_pick_dialog_title),
+        body = stringResource(
+            when (pickListType) {
+                PickListType.FAVORITE -> R.string.delete_selected_favorite_pick_dialog_body
+                PickListType.CREATED -> R.string.delete_selected_pick_dialog_body
+            },
+            selectedPickCount
+        ),
         buttons = {
-            if (selectedPickCount == 0) {
-                DialogTextButton(
-                    onClick = onDismissRequest,
-                    text = stringResource(R.string.confirm_text)
-                )
-            } else {
-                DialogTextButton(
-                    onClick = onDismissRequest,
-                    text = stringResource(R.string.delete_pick_dialog_cancel)
-                )
+            DialogTextButton(
+                onClick = onDismissRequest,
+                text = stringResource(R.string.delete_pick_dialog_cancel)
+            )
 
-                HorizontalSpacer(8)
+            HorizontalSpacer(8)
 
-                DialogTextButton(
-                    onClick = onDeletePickClick,
-                    text = stringResource(R.string.delete_pick_dialog_delete),
-                    textColor = Primary,
-                    fontWeight = FontWeight.Bold
-                )
-            }
+            DialogTextButton(
+                onClick = onDeletePickClick,
+                text = stringResource(R.string.delete_pick_dialog_delete),
+                textColor = Primary,
+                fontWeight = FontWeight.Bold
+            )
         },
     )
 }

--- a/app/src/main/java/com/squirtles/musicroad/picklist/DeleteSelectedPickDialog.kt
+++ b/app/src/main/java/com/squirtles/musicroad/picklist/DeleteSelectedPickDialog.kt
@@ -4,9 +4,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import com.squirtles.musicroad.R
-import com.squirtles.musicroad.common.AlertStringDialog
 import com.squirtles.musicroad.common.DialogTextButton
 import com.squirtles.musicroad.common.HorizontalSpacer
+import com.squirtles.musicroad.common.MessageAlertDialog
 import com.squirtles.musicroad.ui.theme.Primary
 
 @Composable
@@ -16,7 +16,7 @@ internal fun DeleteSelectedPickDialog(
     onDismissRequest: () -> Unit,
     onDeletePickClick: () -> Unit,
 ) {
-    AlertStringDialog(
+    MessageAlertDialog(
         onDismissRequest = onDismissRequest,
         title = stringResource(if (selectedPickCount == 0) R.string.default_alert_dialog_title else R.string.delete_pick_dialog_title),
         body = if (selectedPickCount == 0) {

--- a/app/src/main/java/com/squirtles/musicroad/picklist/EditModeAction.kt
+++ b/app/src/main/java/com/squirtles/musicroad/picklist/EditModeAction.kt
@@ -17,16 +17,30 @@ import com.squirtles.musicroad.ui.theme.White
 internal fun EditModeAction(
     isEditMode: Boolean,
     enabled: Boolean,
+    isSelectedEmpty: Boolean,
     activateEditMode: () -> Unit,
+    selectAllPicks: () -> Unit,
+    deselectAllPicks: () -> Unit,
 ) {
     if (isEditMode) {
-        TextButton(
-            onClick = { TODO("픽 목록 전체 선택") }
-        ) {
-            Text(
-                text = stringResource(R.string.pick_list_select_all_button_text),
-                color = White,
-            )
+        if (isSelectedEmpty) {
+            TextButton(
+                onClick = selectAllPicks
+            ) {
+                Text(
+                    text = stringResource(R.string.pick_list_select_all_button_text),
+                    color = White,
+                )
+            }
+        } else {
+            TextButton(
+                onClick = deselectAllPicks
+            ) {
+                Text(
+                    text = stringResource(R.string.pick_list_deselect_all_button_text),
+                    color = White,
+                )
+            }
         }
     } else {
         IconButton(

--- a/app/src/main/java/com/squirtles/musicroad/picklist/EditModeAction.kt
+++ b/app/src/main/java/com/squirtles/musicroad/picklist/EditModeAction.kt
@@ -1,0 +1,46 @@
+package com.squirtles.musicroad.picklist
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import com.squirtles.musicroad.R
+import com.squirtles.musicroad.ui.theme.Gray
+import com.squirtles.musicroad.ui.theme.White
+
+@Composable
+internal fun EditModeAction(
+    isEditMode: Boolean,
+    enabled: Boolean,
+    activateEditMode: () -> Unit,
+) {
+    if (isEditMode) {
+        TextButton(
+            onClick = { TODO("픽 목록 전체 선택") }
+        ) {
+            Text(
+                text = stringResource(R.string.pick_list_select_all_button_text),
+                color = White,
+            )
+        }
+    } else {
+        IconButton(
+            onClick = activateEditMode,
+            enabled = enabled,
+            colors = IconButtonDefaults.iconButtonColors().copy(
+                contentColor = White,
+                disabledContentColor = Gray,
+            )
+        ) {
+            Icon(
+                imageVector = Icons.Default.Edit,
+                contentDescription = stringResource(R.string.pick_list_activate_edit_mode_button_description),
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/squirtles/musicroad/picklist/EditModeBottomButton.kt
+++ b/app/src/main/java/com/squirtles/musicroad/picklist/EditModeBottomButton.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.squirtles.musicroad.R
+import com.squirtles.musicroad.ui.theme.DarkGray
 import com.squirtles.musicroad.ui.theme.Gray
 import com.squirtles.musicroad.ui.theme.MusicRoadTheme
 import com.squirtles.musicroad.ui.theme.Primary
@@ -23,6 +24,7 @@ import com.squirtles.musicroad.ui.theme.White
 
 @Composable
 internal fun EditModeBottomButton(
+    enabled: Boolean,
     deactivateEditMode: () -> Unit,
     showDeletePickDialog: () -> Unit,
 ) {
@@ -37,7 +39,7 @@ internal fun EditModeBottomButton(
             modifier = Modifier
                 .fillMaxHeight()
                 .weight(1f),
-            buttonColor = Gray
+            buttonColor = DarkGray
         )
 
         EditModeButton(
@@ -45,7 +47,8 @@ internal fun EditModeBottomButton(
             onClick = showDeletePickDialog,
             modifier = Modifier
                 .fillMaxHeight()
-                .weight(1f)
+                .weight(1f),
+            enabled = enabled
         )
     }
 }
@@ -55,16 +58,20 @@ private fun EditModeButton(
     text: String,
     onClick: () -> Unit,
     modifier: Modifier,
+    enabled: Boolean = true,
     textColor: Color = White,
     buttonColor: Color = Primary,
 ) {
     Button(
         onClick = onClick,
         modifier = modifier,
+        enabled = enabled,
         shape = RectangleShape,
         colors = ButtonDefaults.buttonColors().copy(
             containerColor = buttonColor,
-            contentColor = textColor
+            contentColor = textColor,
+            disabledContainerColor = Gray,
+            disabledContentColor = White
         )
     ) {
         Text(
@@ -79,6 +86,7 @@ private fun EditModeButton(
 private fun EditModeBottomButtonPreview() {
     MusicRoadTheme {
         EditModeBottomButton(
+            enabled = true,
             deactivateEditMode = {},
             showDeletePickDialog = {},
         )

--- a/app/src/main/java/com/squirtles/musicroad/picklist/EditModeBottomButton.kt
+++ b/app/src/main/java/com/squirtles/musicroad/picklist/EditModeBottomButton.kt
@@ -24,6 +24,7 @@ import com.squirtles.musicroad.ui.theme.White
 @Composable
 internal fun EditModeBottomButton(
     deactivateEditMode: () -> Unit,
+    showDeletePickDialog: () -> Unit,
 ) {
     Row(
         modifier = Modifier
@@ -43,7 +44,7 @@ internal fun EditModeBottomButton(
             modifier = Modifier
                 .fillMaxHeight()
                 .weight(1f),
-            onClick = { TODO("선택 삭제") },
+            onClick = showDeletePickDialog,
             text = stringResource(R.string.pick_list_delete_selection_button_text)
         )
     }
@@ -79,6 +80,7 @@ private fun EditModeBottomButtonPreview() {
     MusicRoadTheme {
         EditModeBottomButton(
             deactivateEditMode = {},
+            showDeletePickDialog = {},
         )
     }
 }

--- a/app/src/main/java/com/squirtles/musicroad/picklist/EditModeBottomButton.kt
+++ b/app/src/main/java/com/squirtles/musicroad/picklist/EditModeBottomButton.kt
@@ -39,7 +39,7 @@ internal fun EditModeBottomButton(
             modifier = Modifier
                 .fillMaxHeight()
                 .weight(1f),
-            buttonColor = DarkGray
+            buttonColor = Gray
         )
 
         EditModeButton(
@@ -70,7 +70,7 @@ private fun EditModeButton(
         colors = ButtonDefaults.buttonColors().copy(
             containerColor = buttonColor,
             contentColor = textColor,
-            disabledContainerColor = Gray,
+            disabledContainerColor = DarkGray,
             disabledContentColor = White
         )
     ) {

--- a/app/src/main/java/com/squirtles/musicroad/picklist/EditModeBottomButton.kt
+++ b/app/src/main/java/com/squirtles/musicroad/picklist/EditModeBottomButton.kt
@@ -1,0 +1,86 @@
+package com.squirtles.musicroad.picklist
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.squirtles.musicroad.R
+import com.squirtles.musicroad.ui.theme.Gray
+import com.squirtles.musicroad.ui.theme.MusicRoadTheme
+import com.squirtles.musicroad.ui.theme.Primary
+import com.squirtles.musicroad.ui.theme.White
+
+@Composable
+internal fun EditModeBottomButton(
+    deactivateEditMode: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(ButtonHeight)
+    ) {
+        EditModeButton(
+            modifier = Modifier
+                .fillMaxHeight()
+                .weight(1f),
+            onClick = deactivateEditMode,
+            text = stringResource(R.string.pick_list_deactivate_edit_mode_button_text),
+            buttonColor = Gray
+        )
+
+        EditModeButton(
+            modifier = Modifier
+                .fillMaxHeight()
+                .weight(1f),
+            onClick = { TODO("선택 삭제") },
+            text = stringResource(R.string.pick_list_delete_selection_button_text)
+        )
+    }
+}
+
+@Composable
+private fun EditModeButton(
+    modifier: Modifier,
+    onClick: () -> Unit,
+    text: String,
+    textColor: Color = White,
+    buttonColor: Color = Primary,
+) {
+    Button(
+        onClick = onClick,
+        modifier = modifier,
+        shape = RectangleShape,
+        colors = ButtonDefaults.buttonColors().copy(
+            containerColor = buttonColor,
+            contentColor = textColor
+        )
+    ) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.bodyLarge
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun EditModeBottomButtonPreview() {
+    MusicRoadTheme {
+        EditModeBottomButton(
+            deactivateEditMode = {},
+        )
+    }
+}
+
+private val ButtonHeight = 48.dp

--- a/app/src/main/java/com/squirtles/musicroad/picklist/EditModeBottomButton.kt
+++ b/app/src/main/java/com/squirtles/musicroad/picklist/EditModeBottomButton.kt
@@ -32,29 +32,29 @@ internal fun EditModeBottomButton(
             .height(ButtonHeight)
     ) {
         EditModeButton(
+            text = stringResource(R.string.pick_list_deactivate_edit_mode_button_text),
+            onClick = deactivateEditMode,
             modifier = Modifier
                 .fillMaxHeight()
                 .weight(1f),
-            onClick = deactivateEditMode,
-            text = stringResource(R.string.pick_list_deactivate_edit_mode_button_text),
             buttonColor = Gray
         )
 
         EditModeButton(
+            text = stringResource(R.string.pick_list_delete_selection_button_text),
+            onClick = showDeletePickDialog,
             modifier = Modifier
                 .fillMaxHeight()
-                .weight(1f),
-            onClick = showDeletePickDialog,
-            text = stringResource(R.string.pick_list_delete_selection_button_text)
+                .weight(1f)
         )
     }
 }
 
 @Composable
 private fun EditModeButton(
-    modifier: Modifier,
-    onClick: () -> Unit,
     text: String,
+    onClick: () -> Unit,
+    modifier: Modifier,
     textColor: Color = White,
     buttonColor: Color = Primary,
 ) {

--- a/app/src/main/java/com/squirtles/musicroad/picklist/PickItem.kt
+++ b/app/src/main/java/com/squirtles/musicroad/picklist/PickItem.kt
@@ -9,6 +9,9 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.CheckCircle
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.ripple
@@ -17,9 +20,11 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.squirtles.domain.model.Song
+import com.squirtles.musicroad.R
 import com.squirtles.musicroad.common.AlbumImage
 import com.squirtles.musicroad.common.CommentText
 import com.squirtles.musicroad.common.Constants
@@ -32,6 +37,7 @@ import com.squirtles.musicroad.ui.theme.White
 
 @Composable
 internal fun PickItem(
+    isEditMode: Boolean,
     song: Song,
     createdByOthers: Boolean,
     createUserName: String,
@@ -101,6 +107,14 @@ internal fun PickItem(
             CommentText(
                 comment = comment,
                 color = Gray
+            )
+        }
+
+        if (isEditMode) {
+            Icon(
+                imageVector = Icons.Outlined.CheckCircle,
+                contentDescription = stringResource(R.string.outlined_check_circle_icon_description),
+                tint = Gray
             )
         }
     }

--- a/app/src/main/java/com/squirtles/musicroad/picklist/PickItem.kt
+++ b/app/src/main/java/com/squirtles/musicroad/picklist/PickItem.kt
@@ -1,5 +1,6 @@
 package com.squirtles.musicroad.picklist
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
@@ -20,6 +21,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -33,11 +35,13 @@ import com.squirtles.musicroad.common.FavoriteCountText
 import com.squirtles.musicroad.common.HorizontalSpacer
 import com.squirtles.musicroad.common.SongInfoText
 import com.squirtles.musicroad.ui.theme.Gray
+import com.squirtles.musicroad.ui.theme.Primary
 import com.squirtles.musicroad.ui.theme.White
 
 @Composable
 internal fun PickItem(
     isEditMode: Boolean,
+    isSelected: Boolean,
     song: Song,
     createdByOthers: Boolean,
     createUserName: String,
@@ -49,6 +53,7 @@ internal fun PickItem(
     Row(
         modifier = Modifier
             .fillMaxWidth()
+            .background(color = if (isSelected) White.copy(alpha = 0.2F) else Color.Transparent)
             .clickable(
                 interactionSource = remember { MutableInteractionSource() },
                 indication = ripple(color = White),
@@ -114,7 +119,7 @@ internal fun PickItem(
             Icon(
                 imageVector = Icons.Outlined.CheckCircle,
                 contentDescription = stringResource(R.string.outlined_check_circle_icon_description),
-                tint = Gray
+                tint = if (isSelected) Primary else Gray
             )
         }
     }

--- a/app/src/main/java/com/squirtles/musicroad/picklist/PickListScreen.kt
+++ b/app/src/main/java/com/squirtles/musicroad/picklist/PickListScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -60,6 +61,13 @@ fun PickListScreen(
 
     var isEditMode by rememberSaveable { mutableStateOf(false) }
     var showOrderBottomSheet by rememberSaveable { mutableStateOf(false) }
+
+    val deactivateEditMode = remember {
+        {
+            isEditMode = false
+            pickListViewModel.deselectAllPicks()
+        }
+    }
 
     LaunchedEffect(Unit) {
         when (pickListType) {
@@ -121,10 +129,7 @@ fun PickListScreen(
                         onOrderClick = { showOrderBottomSheet = true },
                         onItemClick = onItemClick,
                         onEditModeItemClick = { pickListViewModel.toggleSelectedPick(it) },
-                        deactivateEditMode = {
-                            isEditMode = false
-                            pickListViewModel.deselectAllPicks()
-                        },
+                        deactivateEditMode = deactivateEditMode,
                         onDeletePickClick = {
                             isEditMode = false
                             pickListViewModel.deleteSelectedPicks(pickListType)

--- a/app/src/main/java/com/squirtles/musicroad/picklist/PickListScreen.kt
+++ b/app/src/main/java/com/squirtles/musicroad/picklist/PickListScreen.kt
@@ -221,6 +221,7 @@ private fun PickList(
                     key = { it.id }
                 ) { pick ->
                     PickItem(
+                        isEditMode = isEditMode,
                         song = pick.song,
                         createdByOthers = isFavoritePicks,
                         createUserName = pick.createdBy.userName,

--- a/app/src/main/java/com/squirtles/musicroad/picklist/PickListScreen.kt
+++ b/app/src/main/java/com/squirtles/musicroad/picklist/PickListScreen.kt
@@ -125,6 +125,10 @@ fun PickListScreen(
                             isEditMode = false
                             pickListViewModel.deselectAllPicks()
                         },
+                        onDeletePickClick = {
+                            isEditMode = false
+                            pickListViewModel.deleteSelectedPicks(pickListType)
+                        },
                     )
                 }
 
@@ -164,7 +168,10 @@ private fun PickList(
     onItemClick: (String) -> Unit,
     onEditModeItemClick: (String) -> Unit,
     deactivateEditMode: () -> Unit,
+    onDeletePickClick: () -> Unit,
 ) {
+    var showDeletePickDialog by rememberSaveable { mutableStateOf(false) }
+
     Column(
         modifier = Modifier.fillMaxSize()
     ) {
@@ -249,8 +256,19 @@ private fun PickList(
         if (isEditMode) {
             EditModeBottomButton(
                 deactivateEditMode = deactivateEditMode,
+                showDeletePickDialog = { showDeletePickDialog = true },
             )
         }
+
+        if (showDeletePickDialog) {
+            DeleteSelectedPickDialog(
+                selectedPickCount = selectedPicksId.size,
+                pickListType = pickListType,
+                onDismissRequest = {
+                    showDeletePickDialog = false
+                },
+                onDeletePickClick = onDeletePickClick,
+            )
         }
     }
 }

--- a/app/src/main/java/com/squirtles/musicroad/picklist/PickListScreen.kt
+++ b/app/src/main/java/com/squirtles/musicroad/picklist/PickListScreen.kt
@@ -36,6 +36,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.wear.compose.material.CircularProgressIndicator
 import com.squirtles.domain.model.Order
+import com.squirtles.domain.model.Pick
 import com.squirtles.musicroad.R
 import com.squirtles.musicroad.common.Constants.COLOR_STOPS
 import com.squirtles.musicroad.common.Constants.DEFAULT_PADDING
@@ -96,87 +97,13 @@ fun PickListScreen(
                     val pickList = (uiState as PickListUiState.Success).pickList
                     val order = (uiState as PickListUiState.Success).order
 
-                    Column(
-                        modifier = Modifier.fillMaxSize()
-                    ) {
-                        Row(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(horizontal = DEFAULT_PADDING),
-                            horizontalArrangement = Arrangement.SpaceBetween,
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            TotalCountText(
-                                totalCount = pickList.size,
-                                defaultColor = White,
-                            )
-
-                            Box(
-                                modifier = Modifier
-                                    .wrapContentSize()
-                                    .clip(CircleShape)
-                                    .clickable { showOrderBottomSheet = true }
-                            ) {
-                                Text(
-                                    text = "${
-                                        stringResource(
-                                            when (order) {
-                                                Order.LATEST ->
-                                                    if (isFavoritePicks) R.string.latest_favorite_order else R.string.latest_create_order
-
-                                                Order.OLDEST ->
-                                                    if (isFavoritePicks) R.string.oldest_favorite_order else R.string.oldest_create_order
-
-                                                Order.FAVORITE_DESC -> R.string.favorite_count_desc
-                                            }
-                                        )
-                                    }  ▼",
-                                    modifier = Modifier.padding(
-                                        horizontal = DEFAULT_PADDING / 2,
-                                        vertical = DEFAULT_PADDING / 4
-                                    ),
-                                    color = White,
-                                    style = MaterialTheme.typography.bodyMedium
-                                )
-                            }
-                        }
-
-                        VerticalSpacer(8)
-
-                        if (pickList.isEmpty()) {
-                            Box(
-                                modifier = Modifier.fillMaxSize(),
-                                contentAlignment = Alignment.Center
-                            ) {
-                                Text(
-                                    text = stringResource(
-                                        if (isFavoritePicks) R.string.favorite_picks_empty else R.string.my_picks_empty
-                                    ),
-                                    color = White,
-                                    style = MaterialTheme.typography.titleMedium
-                                )
-                            }
-                        } else {
-                            LazyColumn(
-                                modifier = Modifier.weight(1f)
-                            ) {
-                                items(
-                                    items = pickList,
-                                    key = { it.id }
-                                ) { pick ->
-                                    PickItem(
-                                        song = pick.song,
-                                        createdByOthers = isFavoritePicks,
-                                        createUserName = pick.createdBy.userName,
-                                        favoriteCount = pick.favoriteCount,
-                                        comment = pick.comment,
-                                        createdAt = pick.createdAt,
-                                        onItemClick = { onItemClick(pick.id) }
-                                    )
-                                }
-                            }
-                        }
-                    }
+                    PickList(
+                        isFavoritePicks = isFavoritePicks,
+                        pickList = pickList,
+                        order = order,
+                        onOrderClick = { showOrderBottomSheet = true },
+                        onItemClick = onItemClick
+                    )
                 }
 
                 PickListUiState.Error -> {
@@ -201,5 +128,96 @@ fun PickListScreen(
                 pickListViewModel.setListOrder(isFavoritePicks, order)
             },
         )
+    }
+}
+
+@Composable
+private fun PickList(
+    isFavoritePicks: Boolean,
+    pickList: List<Pick>,
+    order: Order,
+    onOrderClick: () -> Unit,
+    onItemClick: (String) -> Unit,
+) {
+    Column(
+        modifier = Modifier.fillMaxSize()
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = DEFAULT_PADDING),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            TotalCountText(
+                totalCount = pickList.size,
+                defaultColor = White,
+            )
+
+            Box(
+                modifier = Modifier
+                    .wrapContentSize()
+                    .clip(CircleShape)
+                    .clickable { onOrderClick() }
+            ) {
+                Text(
+                    text = "${
+                        stringResource(
+                            when (order) {
+                                Order.LATEST ->
+                                    if (isFavoritePicks) R.string.latest_favorite_order else R.string.latest_create_order
+
+                                Order.OLDEST ->
+                                    if (isFavoritePicks) R.string.oldest_favorite_order else R.string.oldest_create_order
+
+                                Order.FAVORITE_DESC -> R.string.favorite_count_desc
+                            }
+                        )
+                    }  ▼",
+                    modifier = Modifier.padding(
+                        horizontal = DEFAULT_PADDING / 2,
+                        vertical = DEFAULT_PADDING / 4
+                    ),
+                    color = White,
+                    style = MaterialTheme.typography.bodyMedium
+                )
+            }
+        }
+
+        VerticalSpacer(8)
+
+        if (pickList.isEmpty()) {
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = stringResource(
+                        if (isFavoritePicks) R.string.favorite_picks_empty else R.string.my_picks_empty
+                    ),
+                    color = White,
+                    style = MaterialTheme.typography.titleMedium
+                )
+            }
+        } else {
+            LazyColumn(
+                modifier = Modifier.weight(1f)
+            ) {
+                items(
+                    items = pickList,
+                    key = { it.id }
+                ) { pick ->
+                    PickItem(
+                        song = pick.song,
+                        createdByOthers = isFavoritePicks,
+                        createUserName = pick.createdBy.userName,
+                        favoriteCount = pick.favoriteCount,
+                        comment = pick.comment,
+                        createdAt = pick.createdAt,
+                        onItemClick = { onItemClick(pick.id) }
+                    )
+                }
+            }
+        }
     }
 }

--- a/app/src/main/java/com/squirtles/musicroad/picklist/PickListScreen.kt
+++ b/app/src/main/java/com/squirtles/musicroad/picklist/PickListScreen.kt
@@ -41,8 +41,8 @@ import com.squirtles.domain.model.Pick
 import com.squirtles.musicroad.R
 import com.squirtles.musicroad.common.Constants.COLOR_STOPS
 import com.squirtles.musicroad.common.Constants.DEFAULT_PADDING
+import com.squirtles.musicroad.common.CountText
 import com.squirtles.musicroad.common.DefaultTopAppBar
-import com.squirtles.musicroad.common.TotalCountText
 import com.squirtles.musicroad.common.VerticalSpacer
 import com.squirtles.musicroad.ui.theme.Primary
 import com.squirtles.musicroad.ui.theme.White
@@ -187,11 +187,11 @@ private fun PickList(
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically
         ) {
-            TotalCountText(
-                prefixText = stringResource(
+            CountText(
+                totalCount = if (isEditMode) selectedPicksId.size else pickList.size,
+                countLabel = stringResource(
                     if (isEditMode) R.string.selected_count_text else R.string.total_count_text
                 ),
-                totalCount = if (isEditMode) selectedPicksId.size else pickList.size,
                 defaultColor = White,
             )
 

--- a/app/src/main/java/com/squirtles/musicroad/picklist/PickListScreen.kt
+++ b/app/src/main/java/com/squirtles/musicroad/picklist/PickListScreen.kt
@@ -183,7 +183,10 @@ private fun PickList(
             verticalAlignment = Alignment.CenterVertically
         ) {
             TotalCountText(
-                totalCount = pickList.size,
+                prefixText = stringResource(
+                    if (isEditMode) R.string.selected_count_text else R.string.total_count_text
+                ),
+                totalCount = if (isEditMode) selectedPicksId.size else pickList.size,
                 defaultColor = White,
             )
 

--- a/app/src/main/java/com/squirtles/musicroad/picklist/PickListScreen.kt
+++ b/app/src/main/java/com/squirtles/musicroad/picklist/PickListScreen.kt
@@ -56,6 +56,8 @@ fun PickListScreen(
 ) {
     val isLandscape = LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE
     val uiState by pickListViewModel.pickListUiState.collectAsStateWithLifecycle()
+
+    var isEditMode by rememberSaveable { mutableStateOf(false) }
     var showOrderBottomSheet by rememberSaveable { mutableStateOf(false) }
 
     LaunchedEffect(Unit) {
@@ -72,7 +74,14 @@ fun PickListScreen(
                 title = stringResource(
                     if (isFavoritePicks) R.string.favorite_picks_top_app_bar_title else R.string.my_picks_top_app_bar_title
                 ),
-                onBackClick = onBackClick
+                onBackClick = onBackClick,
+                actions = {
+                    EditModeAction(
+                        isEditMode = isEditMode,
+                        enabled = uiState is PickListUiState.Success,
+                        activateEditMode = { isEditMode = true },
+                    )
+                }
             )
         },
     ) { innerPadding ->
@@ -98,11 +107,13 @@ fun PickListScreen(
                     val order = (uiState as PickListUiState.Success).order
 
                     PickList(
+                        isEditMode = isEditMode,
                         isFavoritePicks = isFavoritePicks,
                         pickList = pickList,
                         order = order,
                         onOrderClick = { showOrderBottomSheet = true },
-                        onItemClick = onItemClick
+                        onItemClick = onItemClick,
+                        deactivateEditMode = { isEditMode = false },
                     )
                 }
 
@@ -133,11 +144,13 @@ fun PickListScreen(
 
 @Composable
 private fun PickList(
+    isEditMode: Boolean,
     isFavoritePicks: Boolean,
     pickList: List<Pick>,
     order: Order,
     onOrderClick: () -> Unit,
     onItemClick: (String) -> Unit,
+    deactivateEditMode: () -> Unit,
 ) {
     Column(
         modifier = Modifier.fillMaxSize()
@@ -217,6 +230,12 @@ private fun PickList(
                         onItemClick = { onItemClick(pick.id) }
                     )
                 }
+            }
+
+            if (isEditMode) {
+                EditModeBottomButton(
+                    deactivateEditMode = deactivateEditMode,
+                )
             }
         }
     }

--- a/app/src/main/java/com/squirtles/musicroad/picklist/PickListViewModel.kt
+++ b/app/src/main/java/com/squirtles/musicroad/picklist/PickListViewModel.kt
@@ -31,6 +31,9 @@ class PickListViewModel @Inject constructor(
     private val _pickListUiState = MutableStateFlow<PickListUiState>(PickListUiState.Loading)
     val pickListUiState = _pickListUiState.asStateFlow()
 
+    private val _selectedPicksId = MutableStateFlow<Set<String>>(emptySet())
+    val selectedPicksId = _selectedPicksId.asStateFlow()
+
     fun fetchFavoritePicks(userId: String) {
         viewModelScope.launch {
             fetchFavoritePicksUseCase(userId)
@@ -65,6 +68,22 @@ class PickListViewModel @Inject constructor(
             }
             setList(order)
         }
+    }
+
+    fun toggleSelectedPick(pickId: String) {
+        val curSelectedPicksId = _selectedPicksId.value
+        _selectedPicksId.value =
+            if (curSelectedPicksId.contains(pickId)) curSelectedPicksId - pickId else curSelectedPicksId + pickId
+    }
+
+    fun selectAllPicks() {
+        defaultList?.let { pickList ->
+            _selectedPicksId.value = pickList.map { it.id }.toSet()
+        }
+    }
+
+    fun deselectAllPicks() {
+        _selectedPicksId.value = emptySet()
     }
 
     private fun setList(order: Order) {

--- a/app/src/main/java/com/squirtles/musicroad/picklist/PickListViewModel.kt
+++ b/app/src/main/java/com/squirtles/musicroad/picklist/PickListViewModel.kt
@@ -1,16 +1,22 @@
 package com.squirtles.musicroad.picklist
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.squirtles.domain.model.Order
 import com.squirtles.domain.model.Pick
+import com.squirtles.domain.usecase.favoritepick.DeleteFavoriteUseCase
 import com.squirtles.domain.usecase.favoritepick.FetchFavoritePicksUseCase
+import com.squirtles.domain.usecase.local.GetCurrentUserUseCase
 import com.squirtles.domain.usecase.local.GetFavoriteListOrderUseCase
 import com.squirtles.domain.usecase.local.GetMyListOrderUseCase
 import com.squirtles.domain.usecase.local.SaveFavoriteListOrderUseCase
 import com.squirtles.domain.usecase.local.SaveMyListOrderUseCase
+import com.squirtles.domain.usecase.mypick.DeletePickUseCase
 import com.squirtles.domain.usecase.mypick.FetchMyPicksUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
@@ -20,10 +26,13 @@ import javax.inject.Inject
 class PickListViewModel @Inject constructor(
     private val fetchFavoritePicksUseCase: FetchFavoritePicksUseCase,
     private val fetchMyPicksUseCase: FetchMyPicksUseCase,
+    private val getCurrentUserUseCase: GetCurrentUserUseCase,
     private val getFavoriteListOrderUseCase: GetFavoriteListOrderUseCase,
     private val getMyListOrderUseCase: GetMyListOrderUseCase,
     private val saveFavoriteListOrderUseCase: SaveFavoriteListOrderUseCase,
     private val saveMyListOrderUseCase: SaveMyListOrderUseCase,
+    private val deleteFavoriteUseCase: DeleteFavoriteUseCase,
+    private val deletePickUseCase: DeletePickUseCase,
 ) : ViewModel() {
 
     private var defaultList: List<Pick>? = null
@@ -86,6 +95,32 @@ class PickListViewModel @Inject constructor(
         _selectedPicksId.value = emptySet()
     }
 
+    fun deleteSelectedPicks(type: PickListType) {
+        viewModelScope.launch {
+            _pickListUiState.value = PickListUiState.Loading
+
+            val userId = getUserId()
+            val deleteJobList = _selectedPicksId.value.map { pickId ->
+                when (type) {
+                    PickListType.FAVORITE -> async { deleteFavoriteUseCase(pickId, userId) }
+                    PickListType.CREATED -> async { deletePickUseCase(pickId, userId) }
+                }
+            }
+            val deleteJobResults = deleteJobList.awaitAll()
+
+            deselectAllPicks()
+            if (deleteJobResults.all { it.isSuccess }) {
+                when (type) {
+                    PickListType.FAVORITE -> fetchFavoritePicks(userId)
+                    PickListType.CREATED -> fetchMyPicks(userId)
+                }
+            } else {
+                _pickListUiState.value = PickListUiState.Error
+                Log.e("PickListViewModel", "[픽 목록] 다중 삭제 오류")
+            }
+        }
+    }
+
     private fun setList(order: Order) {
         defaultList?.let { pickList ->
             val sortedList = when (order) {
@@ -103,4 +138,6 @@ class PickListViewModel @Inject constructor(
             )
         }
     }
+
+    private fun getUserId() = getCurrentUserUseCase().userId
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -50,6 +50,10 @@
     <string name="my_picks_empty">등록한 픽이 없습니다</string>
     <string name="error_loading_pick_list">일시적인 오류가 발생했습니다.</string>
 
+    <!-- Pick List -->
+    <string name="pick_list_deactivate_edit_mode_button_text">취소</string>
+    <string name="pick_list_delete_selection_button_text">선택 삭제</string>
+
     <!-- Pick List Order -->
     <string name="latest_create_order">최근 등록순</string>
     <string name="latest_favorite_order">최근 담은순</string>
@@ -79,6 +83,8 @@
 
     <!-- Top App Bar -->
     <string name="top_app_bar_back_description">상단 바 뒤로 가기 버튼</string>
+    <string name="pick_list_activate_edit_mode_button_description">픽 목록 편집 모드 활성화 버튼</string>
+    <string name="pick_list_select_all_button_text">전체 선택</string>
     <string name="favorite_picks_top_app_bar_title">픽 보관함</string>
     <string name="my_picks_top_app_bar_title">등록한 픽</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -86,6 +86,7 @@
     <string name="top_app_bar_back_description">상단 바 뒤로 가기 버튼</string>
     <string name="pick_list_activate_edit_mode_button_description">픽 목록 편집 모드 활성화 버튼</string>
     <string name="pick_list_select_all_button_text">전체 선택</string>
+    <string name="pick_list_deselect_all_button_text">선택 해제</string>
     <string name="favorite_picks_top_app_bar_title">픽 보관함</string>
     <string name="my_picks_top_app_bar_title">등록한 픽</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -82,6 +82,11 @@
     <string name="delete_pick_dialog_cancel">취소</string>
     <string name="delete_pick_dialog_delete">삭제하기</string>
 
+    <string name="default_alert_dialog_title">안내</string>
+    <string name="no_selected_pick_dialog_body">삭제 선택한 픽이 없습니다.</string>
+    <string name="delete_selected_favorite_pick_dialog_body">픽 보관함에서 %d개의 픽이 삭제됩니다.</string>
+    <string name="delete_selected_pick_dialog_body">등록하신 %d개의 픽이 삭제됩니다.</string>
+
     <!-- Top App Bar -->
     <string name="top_app_bar_back_description">상단 바 뒤로 가기 버튼</string>
     <string name="pick_list_activate_edit_mode_button_description">픽 목록 편집 모드 활성화 버튼</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -53,6 +53,7 @@
     <!-- Pick List -->
     <string name="pick_list_deactivate_edit_mode_button_text">취소</string>
     <string name="pick_list_delete_selection_button_text">선택 삭제</string>
+    <string name="outlined_check_circle_icon_description">원 윤곽선이 있는 체크 아이콘</string>
 
     <!-- Pick List Order -->
     <string name="latest_create_order">최근 등록순</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -85,7 +85,7 @@
     <string name="default_alert_dialog_title">안내</string>
     <string name="no_selected_pick_dialog_body">삭제 선택한 픽이 없습니다.</string>
     <string name="delete_selected_favorite_pick_dialog_body">픽 보관함에서 %d개의 픽이 삭제됩니다.</string>
-    <string name="delete_selected_pick_dialog_body">등록하신 %d개의 픽이 삭제됩니다.</string>
+    <string name="delete_selected_pick_dialog_body">선택하신 %d개의 픽이 삭제됩니다.</string>
 
     <!-- Top App Bar -->
     <string name="top_app_bar_back_description">상단 바 뒤로 가기 버튼</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -84,8 +84,6 @@
     <string name="delete_pick_dialog_cancel">취소</string>
     <string name="delete_pick_dialog_delete">삭제하기</string>
 
-    <string name="default_alert_dialog_title">안내</string>
-    <string name="no_selected_pick_dialog_body">삭제 선택한 픽이 없습니다.</string>
     <string name="delete_selected_favorite_pick_dialog_body">픽 보관함에서 %d개의 픽이 삭제됩니다.</string>
     <string name="delete_selected_pick_dialog_body">선택하신 %d개의 픽이 삭제됩니다.</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -54,6 +54,8 @@
     <string name="pick_list_deactivate_edit_mode_button_text">취소</string>
     <string name="pick_list_delete_selection_button_text">선택 삭제</string>
     <string name="outlined_check_circle_icon_description">원 윤곽선이 있는 체크 아이콘</string>
+    <string name="total_count_text">전체</string>
+    <string name="selected_count_text">선택</string>
 
     <!-- Pick List Order -->
     <string name="latest_create_order">최근 등록순</string>


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- resolved: #54 

## 📝 작업 내용 및 코드
픽 목록에서 top app bar actions의 편집 아이콘을 누르면 다중 삭제가 가능하도록 구현했습니다.

https://github.com/user-attachments/assets/e2ef8c81-03a8-4b87-891f-4e8eecf2d494

<h3><a href="https://vaulted-system-3ae.notion.site/161f85098cd580b590c6fea19a723847?pvs=74">구현 과정 보기</a></h3>