### PR TITLE
[refactor] 지도 화면 영역의 픽 목록을 가져오는 시점 변경

### DIFF
--- a/app/src/main/java/com/squirtles/musicroad/map/MapViewModel.kt
+++ b/app/src/main/java/com/squirtles/musicroad/map/MapViewModel.kt
@@ -2,6 +2,7 @@ package com.squirtles.musicroad.map
 
 import android.content.Context
 import android.location.Location
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.naver.maps.geometry.LatLng
@@ -34,6 +35,9 @@ class MapViewModel @Inject constructor(
     private val fetchPickInAreaUseCase: FetchPickInAreaUseCase,
     private val getCurrentUserUseCase: GetCurrentUserUseCase
 ) : ViewModel() {
+
+    private val _centerLatLng: MutableStateFlow<LatLng?> = MutableStateFlow(null)
+    val centerLatLng = _centerLatLng.asStateFlow()
 
     private var _lastCameraPosition: CameraPosition? = null
     val lastCameraPosition get() = _lastCameraPosition
@@ -97,6 +101,10 @@ class MapViewModel @Inject constructor(
         } ?: -1.0
     }
 
+    fun updateCenterLatLng(latLng: LatLng) {
+        _centerLatLng.value = latLng
+    }
+
     fun setClickedMarker(context: Context, marker: Marker) {
         viewModelScope.launch {
             marker.toggleSizeByClick(context, true)
@@ -129,34 +137,33 @@ class MapViewModel @Inject constructor(
         }
     }
 
-    fun fetchPicksInBounds(leftTop: LatLng, rightBottom: LatLng, clusterer: Clusterer<MarkerKey>?) {
+    fun fetchPicksInBounds(leftTop: LatLng, clusterer: Clusterer<MarkerKey>?) {
         viewModelScope.launch {
-            val center = LatLng(
-                (leftTop.latitude + rightBottom.latitude) / 2,
-                (leftTop.longitude + rightBottom.longitude) / 2
-            )
-            val radiusInM = leftTop.distanceTo(rightBottom)
-            val fetchPicks = fetchPickInAreaUseCase(center.latitude, center.longitude, radiusInM)
+            _centerLatLng.value?.run {
+                val radiusInM = leftTop.distanceTo(this)
+                val fetchPicks = fetchPickInAreaUseCase(this.latitude, this.longitude, radiusInM)
 
-            fetchPicks.onSuccess { pickList ->
-                val newKeyTagMap: MutableMap<MarkerKey, String> = mutableMapOf()
-                pickList.forEach { pick ->
-                    newKeyTagMap[MarkerKey(pick)] = pick.id
-                    _picks[pick.id] = pick
-                }
-                _clickedMarkerState.value.clusterPickList?.let { clusterPickList -> // 클러스터 마커가 선택되어 있는 경우
-                    val updatedPickList = mutableListOf<Pick>()
-                    clusterPickList.forEach { pick ->
-                        _picks[pick.id]?.let { updatedPick ->
-                            updatedPickList.add(updatedPick)
-                        }
+                fetchPicks.onSuccess { pickList ->
+                    val newKeyTagMap: MutableMap<MarkerKey, String> = mutableMapOf()
+                    pickList.forEach { pick ->
+                        newKeyTagMap[MarkerKey(pick)] = pick.id
+                        _picks[pick.id] = pick
                     }
-                    _clickedMarkerState.emit(_clickedMarkerState.value.copy(clusterPickList = updatedPickList.toList())) // 최신 픽 정보로 clusterPickList 업데이트
+                    _clickedMarkerState.value.clusterPickList?.let { clusterPickList -> // 클러스터 마커가 선택되어 있는 경우
+                        val updatedPickList = mutableListOf<Pick>()
+                        clusterPickList.forEach { pick ->
+                            _picks[pick.id]?.let { updatedPick ->
+                                updatedPickList.add(updatedPick)
+                            }
+                        }
+                        _clickedMarkerState.emit(_clickedMarkerState.value.copy(clusterPickList = updatedPickList.toList())) // 최신 픽 정보로 clusterPickList 업데이트
+                    }
+                    clusterer?.addAll(newKeyTagMap)
                 }
-                clusterer?.addAll(newKeyTagMap)
-            }
-            fetchPicks.onFailure {
-                // TODO: NoSuchPickInRadiusException일 때
+                fetchPicks.onFailure {
+                    // TODO: NoSuchPickInRadiusException일 때
+                    Log.e("MapViewModel", "${it.message}")
+                }
             }
         }
     }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- resolved #165 

## 📝 작업 내용 및 코드
- StateFlow를 적용하여 지도 화면 영역의 픽 목록을 불러오는 시점을 변경했습니다.

---

### 문제 상황
기존에 지도 화면에 존재하는 픽을 불러오는 시점은 지도 [카메라 대기 이벤트](https://navermaps.github.io/android-map-sdk/guide-ko/3-2.html)가 발생했을 때로 설정해두었다.

```kotlin
// 카메라 대기 이벤트 설정
private fun NaverMap.setCameraIdleListener(
    fetchPicksInBounds: (LatLng, LatLng) -> Unit
) {
    addOnCameraIdleListener {
        val leftTop = projection.fromScreenLocation(PointF(0f, 0f))
        val rightBottom =
            projection.fromScreenLocation(PointF(contentWidth.toFloat(), contentHeight.toFloat()))
        fetchPicksInBounds(leftTop, rightBottom)
    }
}
```

<br>

현재 프로젝트에서 카메라 대기 이벤트는 아래 경우에서 발생한다.

- 사용자가 제스처로 지도를 움직이는 경우 → 제스처가 완전히 끝난 후 카메라 대기 이벤트 발생
- 사용자가 마커를 클릭하면 카메라 대기 이벤트 발생

사용자가 마커를 클릭하면 지도 중앙에 마커가 위치할 수 있도록 카메라의 위치를 이동시켰다.

```kotlin
internal fun setCameraToMarker(
    map: NaverMap,
    clickedMarkerPosition: LatLng
) {
    val cameraUpdate = CameraUpdate
        .scrollTo(clickedMarkerPosition)
        .animate(CameraAnimation.Easing)
    map.moveCamera(cameraUpdate)
}
```

<br>

카메라 위치를 이동시키면 카메라 이동 이벤트 발생 후에 카메라 대기 이벤트가 발생한다. 카메라 대기 이벤트 발생 시 지도 화면 영역의 픽을 불러오기 때문에 사용자가 마커를 클릭하면 지도 화면 영역의 픽 목록을 불러온다.
카메라 대기 이벤트 발생 시 로그를 찍었을 때 사용자의 제스처가 완전히 끝난 후와 마커를 클릭할 때마다 지도 화면 영역의 픽 목록을 불러오는 것을 아래에서 확인할 수 있다.

![카메라 대기 이벤트 발생 로그](https://github.com/user-attachments/assets/7348eb42-2756-4140-8d5d-cbdf4b43767c)

같은 마커를 계속 클릭했을 때도 지도 화면 영역의 픽을 불러오는데 만약 지도 화면 영역의 픽 목록에 변함이 없다면 이 작업은 불필요하고 비효율적이라고 생각했다. 특히 단말 마커는 클릭된 상태에서 이 마커를 계속 클릭하면 이때도 픽 목록을 불러오게 된다. 같은 클러스터 마커를 클릭할 때마다도 픽 목록을 불러온다.

![클릭된 or 같은 마커 클릭](https://github.com/user-attachments/assets/67d72856-adec-40e3-a7d5-31bbf10c1529)

마커 클릭 시 카메라 위치 이동 함수 호출에 따라 카메라 이동은 수행되지만 실제로는 같은 위치로 이동하여 사용자가 보는 지도 화면은 변함이 없다. 따라서 지도 화면 영역의 픽 목록을 불러오는 시점을 변경하는 것이 좋을 것 같다고 판단했다.


### 해결 과정
기존에는 카메라 대기 이벤트가 발생하면 중심 좌표와 반경을 이용해서 무조건 픽 목록을 불러오도록 했었는데, 지도 대기 이벤트가 발생했을 때의 현재 지도의 중심 좌표를 뷰모델에서 StateFlow로 관리하고 이 값이 바뀔 때 픽 목록을 불러오면 지도 대기 이벤트가 발생했을 때 같은 중심 좌표인 경우(클릭된 마커거나 같은 마커 클릭 시)에는 픽 목록을 불러오지 않을 수 있다.

```kotlin
// MapViewModel.kt
private val _centerLatLng: MutableStateFlow<LatLng?> = MutableStateFlow(null)
val centerLatLng = _centerLatLng.asStateFlow()

fun updateCenterLatLng(latLng: LatLng) {
    _centerLatLng.value = latLng
}

fun fetchPicksInBounds(leftTop: LatLng, clusterer: Clusterer<MarkerKey>?) {
    viewModelScope.launch {
        _centerLatLng.value?.run {
            val radiusInM = leftTop.distanceTo(this)
            val fetchPicks = fetchPickInAreaUseCase(this.latitude, this.longitude, radiusInM)

            fetchPicks.onSuccess { pickList ->
                val newKeyTagMap: MutableMap<MarkerKey, String> = mutableMapOf()
                pickList.forEach { pick ->
                    newKeyTagMap[MarkerKey(pick)] = pick.id
                    _picks[pick.id] = pick
                }
                _clickedMarkerState.value.clusterPickList?.let { clusterPickList -> // 클러스터 마커가 선택되어 있는 경우
                    val updatedPickList = mutableListOf<Pick>()
                    clusterPickList.forEach { pick ->
                        _picks[pick.id]?.let { updatedPick ->
                            updatedPickList.add(updatedPick)
                        }
                    }
                    _clickedMarkerState.emit(_clickedMarkerState.value.copy(clusterPickList = updatedPickList.toList())) // 최신 픽 정보로 clusterPickList 업데이트
                }
                clusterer?.addAll(newKeyTagMap)
            }
            fetchPicks.onFailure {
                // TODO: NoSuchPickInRadiusException일 때
            }
        }
    }
}

// NaverMap.kt
val centerLatLng by mapViewModel.centerLatLng.collectAsStateWithLifecycle()

LaunchedEffect(centerLatLng) {
    naverMap.value?.projection?.fromScreenLocation(PointF(0f, 0f))?.run {
        mapViewModel.fetchPicksInBounds(
            leftTop = this,
            clusterer = clusterer
        )
    }
}

AndroidView(
    factory = {
        mapView.apply {
            coroutineScope.launch {
                naverMap.value?.run {
                    setCameraIdleListener { centerLatLng ->
                        mapViewModel.updateCenterLatLng(centerLatLng)
                    }
                }
            }
        }
    },
)

private fun NaverMap.setCameraIdleListener(
    updateCenterLatLng: (LatLng) -> Unit
) {
    addOnCameraIdleListener {
        updateCenterLatLng(cameraPosition.target)
    }
}
```

![개선](https://github.com/user-attachments/assets/f97577e9-019a-4a87-9388-a451e5815609)

<br>

MapViewModel은 모든 Screen에서 살아있기 때문에(MapViewModel을 MainActivity에서 선언했기 때문) 다른 화면으로 갔다와도 StateFlow의 값이 유지된다. 따라서 위처럼만 하게 되면 다른 화면에서 다시 지도 화면으로 오면 픽들이 지도에 표시되지 않는다. `centerLatLng`이 변할 때 픽 목록을 불러오도록 했는데 다른 화면을 다녀오는 것은 `centerLatLng`이 유지되기 때문에 화면을 움직여줬을 때 그제서야 픽 목록을 불러온다.

<img src="https://github.com/user-attachments/assets/4b66b606-8cb1-4c8c-984c-0edfcc817cde" width="300">

`fetchPicksInBounds()`는 `centerLatLng`이 null이 아닐 때만 수행되므로 naverMap이 준비되었을 때도 마지막 카메라 위치가 있으면 픽 목록을 불러오도록 했다.

```kotlin
fun fetchPicksInBounds(leftTop: LatLng, clusterer: Clusterer<MarkerKey>?) {
    viewModelScope.launch {
        _centerLatLng.value?.run {
            // ...
        }
    }
}
```

naverMap이 준비되었을 때 마지막 카메라 위치가 있으면 `fetchPicksInBounds()`를 호출하도록 코드를 추가했다. 처음에는 아래와 같이 `LaunchedEffect(centerLatLng)`에서 쓴 것처럼 `*projection*.fromScreenLocation(PointF(0F, 0F))`을 leftTop 값으로 썼는데 이렇게 하니 다른 화면을 다녀와도 픽 목록이 로드되었다.

```kotlin
naverMap.value?.run {
		// ...
		mapViewModel.lastCameraPosition?.let {
		    mapViewModel.fetchPicksInBounds(
		        leftTop = this.projection.fromScreenLocation(PointF(0F, 0F)),
		        clusterer = clusterer
		    )
		}
}
```

그러나 목록이 일부만 로드되는 경우가 있었다.

|<img src="https://github.com/user-attachments/assets/f713966a-5604-48d6-9e41-771d5885f6bc" width="300">|<img src="https://github.com/user-attachments/assets/961ec6d7-4af3-46df-bd31-d67e3fa6cd03" width="300">|
|:---:|:---:|

<br>

원인을 파악하기 위해 픽 불러오기 함수를 호출했을 때 `centerLatLng`(중심 위도 경도)과 반경을 로그로 출력해봤다.

![image (4)](https://github.com/user-attachments/assets/80e3a348-e5f2-407e-ab14-0dc43529efc0)
![image (5)](https://github.com/user-attachments/assets/347a1007-3a54-4074-892a-e5c396320897)
![image (6)](https://github.com/user-attachments/assets/37e9b21a-4e07-48d1-8de1-35c4591c0431)

지도 화면에서 다른 화면으로 진입한 후 다시 지도 화면으로 왔을 때 중심은 같지만 반경이 달랐다.

위를 보면 마지막 카메라 위치가 존재할 때 화면의 (0, 0) 좌표를 위경도 좌표로 바꾸는 작업을 지도가 준비되었을 때 작업에 추가했다. 지도가 준비되었을 때 하는 작업은 여러 가지가 있다. 그 중에서 마지막 카메라 위치가 있으면 현재 카메라 위치를 마지막 카메라 위치로 이동시켜주는 작업이 있다. 만약 카메라 위치를 마지막 카메라 위치로 이동시키는 작업이 수행되기 전에 `fromScreenLocation(PointF(0F, 0F))`를 수행한다면 어떤 화면의 (0, 0)을 위경도 좌표로 변환하는지 알 수 없다는 뜻이다. 이를 원인으로 생각하고 마지막 카메라 위치가 있을 때 현재 카메라 위치를 이로 바꾸는 작업이 수행된 후 `fromScreenLocation(PointF(0F, 0F))`를 수행하고 픽 목록을 불러오도록 수정했다.

마지막 카메라 위치가 있으면 현재 카메라 위치를 마지막 카메라 위치로 이동시켜주는 작업은 `initDeviceLocation()`에서 수행하고 있었기에 픽 목록을 불러오는 것도 이 함수 안에서 처리될 수 있도록 했다.

```kotlin
naverMap.value?.run {
	  initDeviceLocation(
	      context = context,
	      circleOverlay = circleOverlay,
	      fusedLocationClient = fusedLocationClient,
	      lastCameraPosition = mapViewModel.lastCameraPosition
	  ) {
	      mapViewModel.fetchPicksInBounds(
	          leftTop = this.projection.fromScreenLocation(PointF(0F, 0F)),
	          clusterer = clusterer
	      )
	  }
}

private fun NaverMap.initDeviceLocation(
    context: Context,
    circleOverlay: CircleOverlay,
    fusedLocationClient: FusedLocationProviderClient,
    lastCameraPosition: CameraPosition?,
    fetchPicksInBounds: () -> Unit, // 추가
) {
		// ...
    lastCameraPosition?.let {
        moveCamera(CameraUpdate.toCameraPosition(it))
        fetchPicksInBounds() // 추가
    } ?: run {
        moveCamera(CameraUpdate.scrollTo(LatLng(location)))
        moveCamera(CameraUpdate.zoomTo(INITIAL_CAMERA_ZOOM))
    }
}
```

이렇게 수정하여 발생했던 문제를 해결할 수 있었다.

![image (4)](https://github.com/user-attachments/assets/e16253b6-5d8e-4a94-b9c3-30706354c8cc)
![image (5)](https://github.com/user-attachments/assets/7bb50a47-6419-4739-a733-b68d3e15cf5f)

|<img src="https://github.com/user-attachments/assets/21133e4a-853a-4537-880e-73e71fe72ba5" width="300">|<img src="https://github.com/user-attachments/assets/0f3f2547-e1bd-46a4-ac6e-137b99fa2185" width="300">|
|:---:|:---:|

사실 지도가 만약 한 번 생성되고 유지된다면 지도가 준비되었을 때마다 마지막 카메라 위치에 맞춰 지도 화면 영역의 픽 목록을 불러오는 작업을 할 필요는 없을 거라고 생각한다. 또한 다른 화면을 다녀올 때마다 지도가 새로 로드되는 것을 사용자가 느끼지 않을 수 있다. 하지만 우선 지금은 이를 유지하는 방법을 모르겠다. 더군다나 만약 지도를 유지한다고 했을 때 과연 이것이 정말 괜찮을지도 고민이다. 지도가 유지된다면 노래를 듣고 있을 때나 뮤직비디오를 보고 있을 때도 지도가 유지된다는 건데 지도와 미디어가 같이 살아있어도 메모리 관련이나 이외 다른 문제가 없을지 생각해봐야 할 것 같다.

## 💬 리뷰 요구사항
- 아래는 제가 해결 과정의 마지막에 쓴 제 생각인데 어떻게 생각하시는지 궁금합니다!
> 사실 지도가 만약 한 번 생성되고 유지된다면 지도가 준비되었을 때마다 마지막 카메라 위치에 맞춰 지도 화면 영역의 픽 목록을 불러오는 작업을 할 필요는 없을 거라고 생각한다. 또한 다른 화면을 다녀올 때마다 지도가 새로 로드되는 것을 사용자가 느끼지 않을 수 있다. 하지만 우선 지금은 이를 유지하는 방법을 모르겠다. 더군다나 만약 지도를 유지한다고 했을 때 과연 이것이 정말 괜찮을지도 고민이다. 지도가 유지된다면 노래를 듣고 있을 때나 뮤직비디오를 보고 있을 때도 지도가 유지된다는 건데 지도와 미디어가 같이 살아있어도 메모리 관련이나 이외 다른 문제가 없을지 생각해봐야 할 것 같다.