### PR TITLE
[fix] 로그인 실패 시 예외 처리

### DIFF
--- a/app/src/main/java/com/squirtles/musicroad/account/GoogleId.kt
+++ b/app/src/main/java/com/squirtles/musicroad/account/GoogleId.kt
@@ -8,6 +8,7 @@ import androidx.credentials.CredentialManager
 import androidx.credentials.CustomCredential
 import androidx.credentials.GetCredentialRequest
 import androidx.credentials.GetCredentialResponse
+import androidx.credentials.exceptions.GetCredentialProviderConfigurationException
 import androidx.credentials.exceptions.NoCredentialException
 import com.google.android.libraries.identity.googleid.GetGoogleIdOption
 import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential
@@ -18,6 +19,9 @@ import com.squirtles.musicroad.R
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import kotlin.coroutines.suspendCoroutine
 
 class GoogleId(private val context: Context) {
     private val credentialManager = CredentialManager.create(context)
@@ -32,7 +36,10 @@ class GoogleId(private val context: Context) {
         .addCredentialOption(googleIdOption)
         .build()
 
-    private fun signInWithGoogle(result: GetCredentialResponse, onSuccess: (String, GoogleIdTokenCredential) -> Unit) {
+    private suspend fun signInWithGoogle(
+        result: GetCredentialResponse,
+        onSuccess: (String, GoogleIdTokenCredential) -> Unit
+    ) {
         when (val data = result.credential) {
             is CustomCredential -> {
                 if (data.type == GoogleIdTokenCredential.TYPE_GOOGLE_ID_TOKEN_CREDENTIAL) {
@@ -44,30 +51,48 @@ class GoogleId(private val context: Context) {
         }
     }
 
-    private fun signInWithFirebase(googleIdTokenCredential: GoogleIdTokenCredential, onSuccess: (String, GoogleIdTokenCredential) -> Unit) {
+    private suspend fun signInWithFirebase(
+        googleIdTokenCredential: GoogleIdTokenCredential,
+        onSuccess: (String, GoogleIdTokenCredential) -> Unit
+    ) = suspendCoroutine { continuation ->
         val credential = GoogleAuthProvider.getCredential(googleIdTokenCredential.idToken, null)
         FirebaseAuth.getInstance().signInWithCredential(credential)
             .addOnSuccessListener { authResult ->
                 authResult.user?.uid?.let { uid ->
                     Log.d("SignIn", "Firebase 인증 uid : $uid")
                     onSuccess(uid, googleIdTokenCredential)
+                    continuation.resume(true)
                 }
             }
             .addOnFailureListener { exception ->
                 Log.e("SignIn", "Firebase 인증 실패", exception)
+                continuation.resumeWithException(exception)
             }
     }
 
-    fun signIn(onSuccess: (String, GoogleIdTokenCredential) -> Unit) {
+    fun signIn(
+        onSuccess: (String, GoogleIdTokenCredential) -> Unit,
+        onFailure: (Exception) -> Unit
+    ) {
         CoroutineScope(Dispatchers.Main).launch {
             runCatching {
                 val result = credentialManager.getCredential(context, request)
                 signInWithGoogle(result, onSuccess)
             }.onFailure { exception ->
-                when (exception) {
-                    is NoCredentialException -> Toast.makeText(context, context.getString(R.string.google_id_no_credential_exception_message), Toast.LENGTH_SHORT).show()
+                Log.e("SignIn", "SignIn Error : ${exception.message}")
+                if (exception !is Exception) return@onFailure
+
+                // 로그인 실패 시 콜백
+                onFailure(exception)
+
+                // 로그인 실패 시 TOAST
+                val failureMessageId = when (exception) {
+                    // 개발 시 GooglePlay를 지원하지 않는 에뮬레이터를 사용하는 경우, 기기에 로그인 된 구글 게정이 없는 경우 따로 메시지 표시
+                    is GetCredentialProviderConfigurationException -> R.string.google_id_credential_provider_exception_message
+                    is NoCredentialException -> R.string.google_id_no_credential_exception_message
+                    else -> R.string.sign_in_failure_message
                 }
-                Log.e("SignIn", "Google SignIn Error : $exception")
+                Toast.makeText(context, context.getString(failureMessageId), Toast.LENGTH_SHORT).show()
             }
         }
     }

--- a/app/src/main/java/com/squirtles/musicroad/detail/PickDetailScreen.kt
+++ b/app/src/main/java/com/squirtles/musicroad/detail/PickDetailScreen.kt
@@ -358,6 +358,9 @@ fun PickDetailScreen(
                 GoogleId(context).signIn(
                     onSuccess = { uid, credential ->
                         accountViewModel.signIn(uid, credential)
+                    },
+                    onFailure = {
+                        showProcessIndicator = false
                     }
                 )
             },

--- a/app/src/main/java/com/squirtles/musicroad/map/MapScreen.kt
+++ b/app/src/main/java/com/squirtles/musicroad/map/MapScreen.kt
@@ -250,6 +250,9 @@ fun MapScreen(
                 GoogleId(context).signIn(
                     onSuccess = { uid, credential ->
                         accountViewModel.signIn(uid, credential)
+                    },
+                    onFailure = {
+                        showLoadingIndicator = false
                     }
                 )
             },

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -140,7 +140,9 @@
     <string name="sign_in_dialog_title_user_info">픽을 담기 위해\n로그인이 필요합니다</string>
     <string name="sign_in_dialog">로그인이 필요합니다</string>
     <string name="sign_in_dialog_dismiss">취소</string>
+    <string name="sign_in_failure_message">로그인에 실패했습니다</string>
     <string name="google_id_no_credential_exception_message">기기에 로그인된 구글 계정이 없습니다</string>
+    <string name="google_id_credential_provider_exception_message">Google 로그인을 사용할 수 없는 기기입니다</string>
 
     <!--SignOut-->
     <string name="sign_out_dialog_title">로그아웃 하시겠습니까?</string>


### PR DESCRIPTION
## #️⃣연관된 이슈

> - resolved : #176 

## 📝작업 내용 및 코드

### 로그인 실패 시 콜백 추가
- `SignIn`함수 호출 시 `onFailure`콜백을 추가하여 로그인 실패 시 로딩을 종료하는 등의 작업을 할 수 있도록 했습니다. 

### 예외 전달
- `signInWithFirebase`, `signInWithGoogle` 메서드를 suspend 함수로 변경하여 Firebase 인증 에러를 코루틴 흐름으로 전달할 수 있도록 변경했습니다.
- `addOnFailureListener{}` 내에서 발생한 예외를 `continuation.resumeWithException(exception)`으로 전달해 `runCatching`에서 `catch`되도록 하기 위함입니다. 
- 모든 예외를 `runCatching`으로 전달하여 실패 처리를 일관되게 했습니다. 

### 로그인 실패 시 메시지 
- 의도하지 않은 시스템 에러 발생이외에는 `onFailure`를 실행하고 `Toast`를 띄워줍니다.
- toast의 메세지는 개발 시 주로 실수하기 쉬운 부분인 에뮬레이터 관련 에러 메세지만 따로 분리해뒀습니다! 
  1) google play 지원하지 않는 에뮬레이터
  2) 기기에 구글 로그인이 되어있지 않은 상태 
  3) 이외 로그인 실패 시 -> "로그인에 실패했습니다"

