### PR TITLE
[fix] 검색 버그 해결

### DIFF
--- a/core/model/src/main/java/com/squirtles/core/model/Song.kt
+++ b/core/model/src/main/java/com/squirtles/core/model/Song.kt
@@ -1,6 +1,8 @@
 package com.squirtles.core.model
 
 import kotlinx.serialization.Serializable
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
 
 /**
  * 애플뮤직에서 불러온 노래 정보를 비즈니스 로직에서 사용하기 위해 변환한 클래스
@@ -22,4 +24,16 @@ data class Song(
         else imageUrl.replace("{w}", width.toString())
             .replace("{h}", height.toString())
     }
+
+    fun encoded(): Song = this.copy(
+        songName = URLEncoder.encode(songName, StandardCharsets.UTF_8.toString()).replace("+", "%20"),
+        artistName = URLEncoder.encode(artistName, StandardCharsets.UTF_8.toString()).replace("+", "%20"),
+        albumName = URLEncoder.encode(albumName, StandardCharsets.UTF_8.toString()).replace("+", "%20"),
+        imageUrl = URLEncoder.encode(imageUrl, StandardCharsets.UTF_8.toString()).replace("+", "%20"),
+        previewUrl = URLEncoder.encode(previewUrl, StandardCharsets.UTF_8.toString()).replace("+", "%20"),
+        externalUrl = URLEncoder.encode(externalUrl, StandardCharsets.UTF_8.toString()).replace("+", "%20"),
+        genreNames = genreNames.map {
+            URLEncoder.encode(it, StandardCharsets.UTF_8.toString()).replace("+", "%20")
+        },
+    )
 }

--- a/data/applemusic/src/main/java/com/squirtles/data/applemusic/SearchSongsPagingSource.kt
+++ b/data/applemusic/src/main/java/com/squirtles/data/applemusic/SearchSongsPagingSource.kt
@@ -2,9 +2,9 @@ package com.squirtles.data.applemusic
 
 import androidx.paging.PagingSource
 import androidx.paging.PagingState
+import com.squirtles.core.model.Song
 import com.squirtles.data.applemusic.api.AppleMusicApi
 import com.squirtles.data.applemusic.model.toSong
-import com.squirtles.core.model.Song
 import retrofit2.HttpException
 import java.io.IOException
 

--- a/feature/create/src/main/java/com/squirtles/feature/create/navigation/CreateNavigation.kt
+++ b/feature/create/src/main/java/com/squirtles/feature/create/navigation/CreateNavigation.kt
@@ -5,21 +5,14 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
-import com.squirtles.feature.create.CreatePickScreen
 import com.squirtles.core.model.Song
 import com.squirtles.core.navigation.SearchRoute
 import com.squirtles.core.util.serializableType
-import java.net.URLEncoder
-import java.nio.charset.StandardCharsets
+import com.squirtles.feature.create.CreatePickScreen
 import kotlin.reflect.typeOf
 
 fun NavController.navigateCreate(song: Song, navOptions: NavOptions? = null) {
-    val encodedSong = song.copy(
-        previewUrl = URLEncoder.encode(song.previewUrl, StandardCharsets.UTF_8.toString()),
-        externalUrl = URLEncoder.encode(song.externalUrl, StandardCharsets.UTF_8.toString()),
-        genreNames = song.genreNames.map { URLEncoder.encode(it, StandardCharsets.UTF_8.toString()) },
-        imageUrl = URLEncoder.encode(song.imageUrl, StandardCharsets.UTF_8.toString())
-    )
+    val encodedSong = song.encoded()
     navigate(SearchRoute.Create(encodedSong), navOptions)
 }
 


### PR DESCRIPTION
특정 단어 검색 시 튕기던 버그

## #️⃣연관된 이슈

> ex) #이슈번호

## 📝작업 내용 및 코드

### 검색 버그

특정 단어 검색 시 앱이 죽던 버그가 있었습니다.

추정 원인은 `:feature:create` 모듈의 `CreateNavigation`의

```kotlin
fun NavController.navigateCreate(song: Song, navOptions: NavOptions? = null) {
    val encodedSong = song.copy(
        previewUrl = URLEncoder.encode(song.previewUrl, StandardCharsets.UTF_8.toString()),
        externalUrl = URLEncoder.encode(song.externalUrl, StandardCharsets.UTF_8.toString()),
        genreNames = song.genreNames.map { URLEncoder.encode(it, StandardCharsets.UTF_8.toString()) },
        imageUrl = URLEncoder.encode(song.imageUrl, StandardCharsets.UTF_8.toString())
    )
    navigate(SearchRoute.Create(encodedSong), navOptions)
}
```

에서 Navigation 경로로 `Song` 타입을 보내고 있는 부분인데요.
여기서 `Song` 객체의 프로퍼티 중 '/' 과 같은 문자가 포함되어 있는 경우,
직렬화를 거친 뒤 이 문자들은 네비게이션 경로에 쓰이면 분할자로 인식됩니다.

예를 들어
`search/create/songName=AC/DC` 일때
- "search"
- "create"
- "songName=AC"
- "DC"

이런식으로 경로를 인식하는것인데요

그래서 위 함수처럼 URLEncoder를 적용하면 / → %2F 로 안전하게 변환되기 때문에 해당 문제에서 자유로워집니다.
그런데 이전에 이 처리를 적용할때, 보통 장르에서 주로 '/' 가 사용되어서 (힙합/랩 같이) url과 장르명에만 처리를 해놓았었습니다.
아마 발생했던 버그는 장르명과 url 들을 제외한 다른 프로퍼티에서 '/' 과 같은 문자들이 사용되었고 이 처리를 해놓지 않았던게 원인이었던것같습니다

```kotlin
@Serializable
data class Song(
    ..
) {
    ..

    fun encoded(): Song = this.copy(
        songName = URLEncoder.encode(songName, StandardCharsets.UTF_8.toString()).replace("+", "%20"),
        artistName = URLEncoder.encode(artistName, StandardCharsets.UTF_8.toString()).replace("+", "%20"),
        albumName = URLEncoder.encode(albumName, StandardCharsets.UTF_8.toString()).replace("+", "%20"),
        imageUrl = URLEncoder.encode(imageUrl, StandardCharsets.UTF_8.toString()).replace("+", "%20"),
        previewUrl = URLEncoder.encode(previewUrl, StandardCharsets.UTF_8.toString()).replace("+", "%20"),
        externalUrl = URLEncoder.encode(externalUrl, StandardCharsets.UTF_8.toString()).replace("+", "%20"),
        genreNames = genreNames.map {
            URLEncoder.encode(it, StandardCharsets.UTF_8.toString()).replace("+", "%20")
        },
    )
}
```

그래서 위와같이 `Song` 클래스의 함수로 모든 프로퍼티에 URLEncoder를 적용한 `Song`을 만드는 함수를 넣고
`CreateNavigation` 에서 이를 사용하게 변경하였습니다.

이전 회의 중 c 를 검색했을때 가장 먼저 나오는 노래를 선택해 생성화면으로 넘어갈때 튕겼던걸로 기억하는데
확인하니 이제 등록까지 잘 됩니다.

| | |
|--------|-------|
| ![image](https://github.com/user-attachments/assets/5c3b3378-6db0-4cf6-b809-9b2956e6fc13) | ![image](https://github.com/user-attachments/assets/b63c3244-d251-4ebe-9bb6-fc2c90c4c057) |


### 검색 결과 상이

애플뮤직 앱이나 웹에서 검색한 결과와
저희 앱에서 API 통해 가져온 검색결과가 다르던 문제가 있었는데요

저희 앱에서 요청을 보낼때 문자열이 변형되는 문제가 있나 확인해봤는데 그런건 없는것같고
postman 이용해서 보낸 요청도 받아오는 결과가 저희랑 똑같더라구요

아마 애플뮤직에서 직접 검색하는건 추가적으로 최근 인기있는 순서 같은 정렬이 적용되고
검색어에도 교정이 들어가서 아무래도 더 좋은 결과를 가져오는것 같아요

결과 검색한 단어와 전혀 관련 없어 보이는 결과가 오는건
앨범이름 같은 다른 속성이나 storefront도 영향을 미치나본데 
us로 변경해도 결과가 이상하긴합니다.

이 문제는 보류하는걸로...


## 💬리뷰 요구사항(선택)

혹시 또 검색하다 죽는 단어가 있다면 알려주세요