### PR TITLE
[feature] 약관, 개인정보처리방침, 문의

### DIFF
--- a/feature/userinfo/src/main/java/com/squirtles/feature/userinfo/screen/EditProfileScreen.kt
+++ b/feature/userinfo/src/main/java/com/squirtles/feature/userinfo/screen/EditProfileScreen.kt
@@ -159,7 +159,7 @@ internal fun EditProfileScreen(
                     .padding(vertical = 20.dp)
                     .clickable { showDeleteAccountDialog = true }
                     .align(Alignment.BottomCenter),
-                color = DarkGray,
+                color = White,
                 textAlign = TextAlign.Center,
                 style = MaterialTheme.typography.bodyMedium
             )

--- a/feature/userinfo/src/main/java/com/squirtles/feature/userinfo/screen/EditProfileScreen.kt
+++ b/feature/userinfo/src/main/java/com/squirtles/feature/userinfo/screen/EditProfileScreen.kt
@@ -159,7 +159,7 @@ internal fun EditProfileScreen(
                     .padding(vertical = 20.dp)
                     .clickable { showDeleteAccountDialog = true }
                     .align(Alignment.BottomCenter),
-                color = White,
+                color = Gray,
                 textAlign = TextAlign.Center,
                 style = MaterialTheme.typography.bodyMedium
             )

--- a/feature/userinfo/src/main/java/com/squirtles/feature/userinfo/screen/UserInfoScreen.kt
+++ b/feature/userinfo/src/main/java/com/squirtles/feature/userinfo/screen/UserInfoScreen.kt
@@ -1,7 +1,11 @@
 package com.squirtles.feature.userinfo.screen
 
 import android.annotation.SuppressLint
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
 import android.net.http.SslError
+import android.util.Log
 import android.webkit.SslErrorHandler
 import android.webkit.WebSettings
 import android.webkit.WebSettings.LOAD_DEFAULT
@@ -13,7 +17,10 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentWidth
@@ -32,6 +39,7 @@ import androidx.compose.material.icons.outlined.Notifications
 import androidx.compose.material.icons.outlined.SmartDisplay
 import androidx.compose.material.icons.outlined.SwitchAccount
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Divider
 import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -56,6 +64,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
@@ -168,24 +177,36 @@ fun UserInfoScreenContent(
     onDismissLogOutDialog: () -> Unit,
     onConfirmLogOutDialog: () -> Unit,
 ) {
+    val context = LocalContext.current
     val scrollState = rememberScrollState()
+    val webViewScrollState = rememberScrollState()
 
     val webView = rememberWebView()
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     var showSheet by remember { mutableStateOf(false) }
     var currentWebUrl by remember { mutableStateOf("") }
 
+    // WebPages
+    val termsUrl = stringResource(R.string.terms_page)
+    val policyUrl = stringResource(R.string.privacy_page)
+
     if(showSheet && currentWebUrl.isNotEmpty()) {
         ModalBottomSheet(
             onDismissRequest = { currentWebUrl = "" },
-            sheetState = sheetState
+            sheetState = sheetState,
         ) {
-            webView.loadUrl(currentWebUrl)
-
-            AndroidView(
-                factory = { webView },
-                modifier = Modifier.fillMaxSize()
-            )
+            Column(
+                modifier = Modifier
+                    .fillMaxHeight(0.95f)
+                    .verticalScroll(webViewScrollState)
+            ) {
+                AndroidView(
+                    factory = { webView },
+                    modifier = Modifier.fillMaxSize()
+                ) {
+                    it.loadUrl(currentWebUrl)
+                }
+            }
         }
     }
 
@@ -285,8 +306,8 @@ fun UserInfoScreenContent(
                                 contentDescription = stringResource(R.string.user_info_support_terms_icon_description),
                                 menuTitle = stringResource(R.string.user_info_support_terms_title),
                                 onMenuClick = {
+                                    currentWebUrl = termsUrl
                                     showSheet = true
-                                    currentWebUrl = "https://www.naver.com" // FIXME: Terms page url
                                 }
                             ),
                             MenuItem(
@@ -294,8 +315,8 @@ fun UserInfoScreenContent(
                                 contentDescription = stringResource(R.string.user_info_support_policy_icon_description),
                                 menuTitle = stringResource(R.string.user_info_support_policy_title),
                                 onMenuClick = {
+                                    currentWebUrl = policyUrl
                                     showSheet = true
-                                    currentWebUrl = "https://www.google.com" // FIXME: Policy page url
                                 }
                             )
                         )

--- a/feature/userinfo/src/main/java/com/squirtles/feature/userinfo/screen/UserInfoScreen.kt
+++ b/feature/userinfo/src/main/java/com/squirtles/feature/userinfo/screen/UserInfoScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.material.icons.filled.Policy
 import androidx.compose.material.icons.outlined.AllOut
 import androidx.compose.material.icons.outlined.Archive
 import androidx.compose.material.icons.outlined.Description
+import androidx.compose.material.icons.outlined.EditNote
 import androidx.compose.material.icons.outlined.Map
 import androidx.compose.material.icons.outlined.Notifications
 import androidx.compose.material.icons.outlined.SmartDisplay
@@ -179,35 +180,15 @@ fun UserInfoScreenContent(
 ) {
     val context = LocalContext.current
     val scrollState = rememberScrollState()
-    val webViewScrollState = rememberScrollState()
-
-    val webView = rememberWebView()
-    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
-    var showSheet by remember { mutableStateOf(false) }
-    var currentWebUrl by remember { mutableStateOf("") }
 
     // WebPages
+    val askUrl = stringResource(R.string.ask_page)
     val termsUrl = stringResource(R.string.terms_page)
     val policyUrl = stringResource(R.string.privacy_page)
 
-    if(showSheet && currentWebUrl.isNotEmpty()) {
-        ModalBottomSheet(
-            onDismissRequest = { currentWebUrl = "" },
-            sheetState = sheetState,
-        ) {
-            Column(
-                modifier = Modifier
-                    .fillMaxHeight(0.95f)
-                    .verticalScroll(webViewScrollState)
-            ) {
-                AndroidView(
-                    factory = { webView },
-                    modifier = Modifier.fillMaxSize()
-                ) {
-                    it.loadUrl(currentWebUrl)
-                }
-            }
-        }
+    val startBrowser: (String) -> Unit = { url ->
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
+        context.startActivity(intent)
     }
 
     Scaffold(
@@ -302,12 +283,19 @@ fun UserInfoScreenContent(
                         title = stringResource(R.string.user_info_support_category_title),
                         menus = listOf(
                             MenuItem(
+                                imageVector = Icons.Outlined.EditNote,
+                                contentDescription = stringResource(R.string.user_info_support_ask_icon_description),
+                                menuTitle = stringResource(R.string.user_info_support_ask_title),
+                                onMenuClick = {
+                                    startBrowser(askUrl)
+                                }
+                            ),
+                            MenuItem(
                                 imageVector = Icons.Outlined.Description,
                                 contentDescription = stringResource(R.string.user_info_support_terms_icon_description),
                                 menuTitle = stringResource(R.string.user_info_support_terms_title),
                                 onMenuClick = {
-                                    currentWebUrl = termsUrl
-                                    showSheet = true
+                                    startBrowser(termsUrl)
                                 }
                             ),
                             MenuItem(
@@ -315,8 +303,7 @@ fun UserInfoScreenContent(
                                 contentDescription = stringResource(R.string.user_info_support_policy_icon_description),
                                 menuTitle = stringResource(R.string.user_info_support_policy_title),
                                 onMenuClick = {
-                                    currentWebUrl = policyUrl
-                                    showSheet = true
+                                    startBrowser(policyUrl)
                                 }
                             )
                         )
@@ -388,27 +375,6 @@ fun UserInfoScreenContent(
             }
         }
     }
-}
-
-@SuppressLint("SetJavaScriptEnabled")
-@Composable
-fun rememberWebView(): WebView {
-    val context = LocalContext.current
-    val webView = remember {
-        WebView(context).apply {
-            settings.apply {
-                javaScriptEnabled = true
-                mixedContentMode = WebSettings.MIXED_CONTENT_ALWAYS_ALLOW  // HTTPS/HTTP 혼합 컨텐츠 허용
-                cacheMode = LOAD_DEFAULT
-            }
-            webViewClient = object : WebViewClient() {
-                override fun onReceivedSslError(view: WebView?, handler: SslErrorHandler?, error: SslError?) {
-                    handler?.proceed()  // SSL 에러 무시하고 진행
-                }
-            }
-        }
-    }
-    return webView
 }
 
 @Preview(showBackground = true)

--- a/feature/userinfo/src/main/java/com/squirtles/feature/userinfo/screen/UserInfoScreen.kt
+++ b/feature/userinfo/src/main/java/com/squirtles/feature/userinfo/screen/UserInfoScreen.kt
@@ -16,8 +16,10 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.Logout
 import androidx.compose.material.icons.filled.MusicNote
+import androidx.compose.material.icons.filled.Policy
 import androidx.compose.material.icons.outlined.AllOut
 import androidx.compose.material.icons.outlined.Archive
+import androidx.compose.material.icons.outlined.Description
 import androidx.compose.material.icons.outlined.Map
 import androidx.compose.material.icons.outlined.Notifications
 import androidx.compose.material.icons.outlined.SmartDisplay
@@ -194,7 +196,7 @@ fun UserInfoScreenContent(
                     contentScale = ContentScale.Crop,
                 )
 
-                VerticalSpacer(40)
+                VerticalSpacer(30)
 
                 UserInfoMenus(
                     title = stringResource(R.string.user_info_pick_category_title),
@@ -241,6 +243,24 @@ fun UserInfoScreenContent(
                                 contentDescription = stringResource(R.string.user_info_setting_sign_out_menu_icon_description),
                                 menuTitle = stringResource(R.string.user_info_setting_sign_out_menu_title),
                                 onMenuClick = onLogOutMenuClick
+                            )
+                        )
+                    )
+
+                    UserInfoMenus(
+                        title = stringResource(R.string.user_info_support_category_title),
+                        menus = listOf(
+                            MenuItem(
+                                imageVector = Icons.Outlined.Description,
+                                contentDescription = stringResource(R.string.user_info_support_terms_icon_description),
+                                menuTitle = stringResource(R.string.user_info_support_terms_title),
+                                onMenuClick = onFavoritePicksClick
+                            ),
+                            MenuItem(
+                                imageVector = Icons.Default.Policy,
+                                contentDescription = stringResource(R.string.user_info_support_policy_icon_description),
+                                menuTitle = stringResource(R.string.user_info_support_policy_title),
+                                onMenuClick = onMyPicksClick
                             )
                         )
                     )

--- a/feature/userinfo/src/main/java/com/squirtles/feature/userinfo/screen/UserInfoScreen.kt
+++ b/feature/userinfo/src/main/java/com/squirtles/feature/userinfo/screen/UserInfoScreen.kt
@@ -1,5 +1,12 @@
 package com.squirtles.feature.userinfo.screen
 
+import android.annotation.SuppressLint
+import android.net.http.SslError
+import android.webkit.SslErrorHandler
+import android.webkit.WebSettings
+import android.webkit.WebSettings.LOAD_DEFAULT
+import android.webkit.WebView
+import android.webkit.WebViewClient
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -28,13 +35,16 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -48,6 +58,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LocalLifecycleOwner
@@ -159,6 +170,25 @@ fun UserInfoScreenContent(
 ) {
     val scrollState = rememberScrollState()
 
+    val webView = rememberWebView()
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    var showSheet by remember { mutableStateOf(false) }
+    var currentWebUrl by remember { mutableStateOf("") }
+
+    if(showSheet && currentWebUrl.isNotEmpty()) {
+        ModalBottomSheet(
+            onDismissRequest = { currentWebUrl = "" },
+            sheetState = sheetState
+        ) {
+            webView.loadUrl(currentWebUrl)
+
+            AndroidView(
+                factory = { webView },
+                modifier = Modifier.fillMaxSize()
+            )
+        }
+    }
+
     Scaffold(
         topBar = {
             DefaultTopAppBar(
@@ -254,13 +284,19 @@ fun UserInfoScreenContent(
                                 imageVector = Icons.Outlined.Description,
                                 contentDescription = stringResource(R.string.user_info_support_terms_icon_description),
                                 menuTitle = stringResource(R.string.user_info_support_terms_title),
-                                onMenuClick = onFavoritePicksClick
+                                onMenuClick = {
+                                    showSheet = true
+                                    currentWebUrl = "https://www.naver.com" // FIXME: Terms page url
+                                }
                             ),
                             MenuItem(
                                 imageVector = Icons.Default.Policy,
                                 contentDescription = stringResource(R.string.user_info_support_policy_icon_description),
                                 menuTitle = stringResource(R.string.user_info_support_policy_title),
-                                onMenuClick = onMyPicksClick
+                                onMenuClick = {
+                                    showSheet = true
+                                    currentWebUrl = "https://www.google.com" // FIXME: Policy page url
+                                }
                             )
                         )
                     )
@@ -331,6 +367,27 @@ fun UserInfoScreenContent(
             }
         }
     }
+}
+
+@SuppressLint("SetJavaScriptEnabled")
+@Composable
+fun rememberWebView(): WebView {
+    val context = LocalContext.current
+    val webView = remember {
+        WebView(context).apply {
+            settings.apply {
+                javaScriptEnabled = true
+                mixedContentMode = WebSettings.MIXED_CONTENT_ALWAYS_ALLOW  // HTTPS/HTTP 혼합 컨텐츠 허용
+                cacheMode = LOAD_DEFAULT
+            }
+            webViewClient = object : WebViewClient() {
+                override fun onReceivedSslError(view: WebView?, handler: SslErrorHandler?, error: SslError?) {
+                    handler?.proceed()  // SSL 에러 무시하고 진행
+                }
+            }
+        }
+    }
+    return webView
 }
 
 @Preview(showBackground = true)

--- a/feature/userinfo/src/main/res/values/strings.xml
+++ b/feature/userinfo/src/main/res/values/strings.xml
@@ -23,6 +23,11 @@
     <string name="user_info_setting_notification_menu_icon_description">알림 메뉴 아이콘</string>
     <string name="user_info_setting_sound_effect_menu_icon_description">사운드효과 메뉴 아이콘</string>
     <string name="user_info_setting_sign_out_menu_icon_description">로그아웃 메뉴 아이콘</string>
+    <string name="user_info_support_category_title">Support</string>
+    <string name="user_info_support_terms_title">이용약관</string>
+    <string name="user_info_support_terms_icon_description">이용약관 메뉴 아이콘</string>
+    <string name="user_info_support_policy_title">개인정보처리방침</string>
+    <string name="user_info_support_policy_icon_description">개인정보처리방침 메뉴 아이콘</string>
     <string name="user_info_icon_map_description">지도 아이콘</string>
     <string name="user_info_back_to_map_button_text">지도로 돌아가기</string>
 

--- a/feature/userinfo/src/main/res/values/strings.xml
+++ b/feature/userinfo/src/main/res/values/strings.xml
@@ -58,4 +58,8 @@
     <string name="sound_effect_bar">막대형</string>
     <string name="sound_effect_wave_fill">파도형</string>
     <string name="sound_effect_wave_stroke">선형</string>
+
+    <!--WebPages-->
+    <string name="terms_page">https://www.naver.com</string>
+    <string name="privacy_page">https://github.com/boostcampwm-2024/and06-musicroad/wiki/%EA%B0%9C%EC%9D%B8%EC%A0%95%EB%B3%B4%EC%B2%98%EB%A6%AC%EB%B0%A9%EC%B9%A8</string>
 </resources>

--- a/feature/userinfo/src/main/res/values/strings.xml
+++ b/feature/userinfo/src/main/res/values/strings.xml
@@ -23,13 +23,17 @@
     <string name="user_info_setting_notification_menu_icon_description">알림 메뉴 아이콘</string>
     <string name="user_info_setting_sound_effect_menu_icon_description">사운드효과 메뉴 아이콘</string>
     <string name="user_info_setting_sign_out_menu_icon_description">로그아웃 메뉴 아이콘</string>
+    <string name="user_info_icon_map_description">지도 아이콘</string>
+    <string name="user_info_back_to_map_button_text">지도로 돌아가기</string>
+
+    <!-- Support -->
     <string name="user_info_support_category_title">Support</string>
+    <string name="user_info_support_ask_title">문의하기</string>
+    <string name="user_info_support_ask_icon_description">문의하기 메뉴 아이콘</string>
     <string name="user_info_support_terms_title">이용약관</string>
     <string name="user_info_support_terms_icon_description">이용약관 메뉴 아이콘</string>
     <string name="user_info_support_policy_title">개인정보처리방침</string>
     <string name="user_info_support_policy_icon_description">개인정보처리방침 메뉴 아이콘</string>
-    <string name="user_info_icon_map_description">지도 아이콘</string>
-    <string name="user_info_back_to_map_button_text">지도로 돌아가기</string>
 
     <!-- Setting -->
     <string name="setting_notification_title">알림 설정</string>
@@ -60,6 +64,7 @@
     <string name="sound_effect_wave_stroke">선형</string>
 
     <!--WebPages-->
-    <string name="terms_page">https://www.naver.com</string>
-    <string name="privacy_page">https://github.com/boostcampwm-2024/and06-musicroad/wiki/%EA%B0%9C%EC%9D%B8%EC%A0%95%EB%B3%B4%EC%B2%98%EB%A6%AC%EB%B0%A9%EC%B9%A8</string>
+    <string name="ask_page">https://docs.google.com/forms/d/e/1FAIpQLSfzko2hlu9ttd-VjiO9qTaPhQxzmS0M_03zVmBu-Da-JsMPnw/viewform?usp=header</string>
+    <string name="terms_page">https://scratch-energy-939.notion.site/20d6f05e19ba80c39b7cd618f07adb1b</string>
+    <string name="privacy_page">https://scratch-energy-939.notion.site/20c6f05e19ba807e8800ec69f54ab09f</string>
 </resources>


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #44 

## 📝작업 내용 및 코드

### 설정 페이지 메뉴 추가

Support 탭 추가했습니다

![image](https://github.com/user-attachments/assets/a90f12a4-562c-4449-8934-fe2541de55cc)


### 문의사항 페이지 연결

구글폼으로 작성 가능한 문의사항 페이지 만들어서 브라우저로 연결되게 만들었어요

https://docs.google.com/forms/d/e/1FAIpQLSfzko2hlu9ttd-VjiO9qTaPhQxzmS0M_03zVmBu-Da-JsMPnw/viewform?usp=header

### 이용약관 페이지 연결

https://scratch-energy-939.notion.site/20d6f05e19ba80c39b7cd618f07adb1b

### 개인정보처리방침 페이지 연결

https://scratch-energy-939.notion.site/20c6f05e19ba807e8800ec69f54ab09f

## 💬리뷰 요구사항(선택)

원래 모두 바텀시트에 웹뷰를 넣어서 만들려고 했는데
웹뷰에서 노션사이트만 자꾸 안열리더라구요
깃헙 위키에 작성하고 이걸 웹뷰로 열게 할까 했는데, 아무래도 노션 페이지가 더 깔끔해서 그냥 기기 브라우저로 연결되도록 했습니다.

문제는 이렇게 만드니 브라우저에서 뒤로가기로 다시 앱으로 돌아올때 앱이 초기화면으로 돌아가 재시작되더라구요
설정 화면이 그대로 유지되도록 하고싶은데 일단은 잘 모르겠습니다...헣허
이것만이 아니라 홈화면 갔다가 앱 다시 열어도 재시작되더라구요 원래이랬는지는??? 모르겠네요


+ 회원탈퇴를 최대한 찾기 힘들도록 하는게 의도긴 했지만 너무 안보여서 글자색만 흰색으로 바꿨는데 괜찮을까요??? ㅋㅋㅋ