### PR TITLE
[feature] 위치권한 선택

### DIFF
--- a/core/common/src/main/java/com/squirtles/core/common/ui/MusicRoadPermissions.kt
+++ b/core/common/src/main/java/com/squirtles/core/common/ui/MusicRoadPermissions.kt
@@ -16,7 +16,7 @@ object MusicRoadPermissions {
         Manifest.permission.RECORD_AUDIO,
     )
 
-    val ALL_PERMISSIONS = OPTIONAL_PERMISSIONS + CORE_PERMISSIONS
+    val ALL_PERMISSIONS = CORE_PERMISSIONS + OPTIONAL_PERMISSIONS
 
     fun checkLocationPermission(context: Context): Boolean {
         return OPTIONAL_PERMISSIONS.all {

--- a/core/common/src/main/java/com/squirtles/core/common/ui/MusicRoadPermissions.kt
+++ b/core/common/src/main/java/com/squirtles/core/common/ui/MusicRoadPermissions.kt
@@ -1,17 +1,26 @@
 package com.squirtles.core.common.ui
 
 import android.Manifest
+import android.content.Context
+import androidx.core.content.PermissionChecker
 
 object MusicRoadPermissions {
     // 선택적 권한
-    val OPTIONAL_PERMISSIONS = listOf<String>()
+    val OPTIONAL_PERMISSIONS = listOf<String>(
+        Manifest.permission.ACCESS_FINE_LOCATION,
+        Manifest.permission.ACCESS_COARSE_LOCATION,
+    )
 
     // 필수 권한
     val CORE_PERMISSIONS = listOf<String>(
-        Manifest.permission.ACCESS_FINE_LOCATION,
-        Manifest.permission.ACCESS_COARSE_LOCATION,
         Manifest.permission.RECORD_AUDIO,
     )
 
     val ALL_PERMISSIONS = OPTIONAL_PERMISSIONS + CORE_PERMISSIONS
+
+    fun checkLocationPermission(context: Context): Boolean {
+        return OPTIONAL_PERMISSIONS.all {
+            PermissionChecker.checkSelfPermission(context, it) == PermissionChecker.PERMISSION_GRANTED
+        }
+    }
 }

--- a/data/firebase/src/main/java/com/squirtles/data/firebase/model/Mapper.kt
+++ b/data/firebase/src/main/java/com/squirtles/data/firebase/model/Mapper.kt
@@ -1,14 +1,14 @@
 package com.squirtles.data.firebase.model
 
 import androidx.core.graphics.toColorInt
+import com.firebase.geofire.GeoFireUtils
+import com.firebase.geofire.GeoLocation
+import com.google.firebase.firestore.GeoPoint
 import com.squirtles.core.model.Creator
 import com.squirtles.core.model.LocationPoint
 import com.squirtles.core.model.Pick
 import com.squirtles.core.model.Song
 import com.squirtles.core.model.User
-import com.firebase.geofire.GeoFireUtils
-import com.firebase.geofire.GeoLocation
-import com.google.firebase.firestore.GeoPoint
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale

--- a/data/location/build.gradle.kts
+++ b/data/location/build.gradle.kts
@@ -9,6 +9,10 @@ android {
 
 dependencies {
     implementation(projects.domain.location)
+    implementation(projects.core.model)
+
+    // Datastore
+    implementation(libs.androidx.datastore.preferences)
 
     testImplementation(libs.junit)
     androidTestImplementation(libs.bundles.test)

--- a/data/location/src/main/java/com/squirtles/data/location/LocalLocationRepositoryImpl.kt
+++ b/data/location/src/main/java/com/squirtles/data/location/LocalLocationRepositoryImpl.kt
@@ -22,11 +22,10 @@ class LocalLocationRepositoryImpl @Inject constructor(
 
     override fun readLastLocation(): Flow<LocationPoint?> {
         return context.dataStore.data.map { preferences ->
-            preferences[latKey]?.let { lat ->
-                preferences[lngKey]?.let { lng ->
-                    LocationPoint(lat.toDouble(), lng.toDouble())
-                }
-            }
+            val lat = preferences[latKey]?.toDoubleOrNull()
+            val lng = preferences[lngKey]?.toDoubleOrNull()
+
+            if (lat != null && lng != null) LocationPoint(lat, lng) else null
         }
     }
 

--- a/data/location/src/main/java/com/squirtles/data/location/LocalLocationRepositoryImpl.kt
+++ b/data/location/src/main/java/com/squirtles/data/location/LocalLocationRepositoryImpl.kt
@@ -1,18 +1,45 @@
 package com.squirtles.data.location
 
-import android.location.Location
+import android.content.Context
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import com.squirtles.core.model.LocationPoint
 import com.squirtles.domain.location.LocalLocationRepository
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class LocalLocationRepositoryImpl : LocalLocationRepository {
-    private var _currentLocation: MutableStateFlow<Location?> = MutableStateFlow(null)
-    override val lastLocation: StateFlow<Location?> = _currentLocation.asStateFlow()
+class LocalLocationRepositoryImpl @Inject constructor(
+    private val context: Context
+) : LocalLocationRepository {
+    private val Context.dataStore by preferencesDataStore(name = LOCATION_PREFERENCES_NAME)
 
-    override suspend fun saveCurrentLocation(geoLocation: Location) {
-        _currentLocation.emit(geoLocation)
+    private val latKey = stringPreferencesKey(LAT_KEY)
+    private val lngKey = stringPreferencesKey(LNG_KEY)
+
+    override fun readLastLocation(): Flow<LocationPoint?> {
+        return context.dataStore.data.map { preferences ->
+            preferences[latKey]?.let { lat ->
+                preferences[lngKey]?.let { lng ->
+                    LocationPoint(lat.toDouble(), lng.toDouble())
+                }
+            }
+        }
+    }
+
+    override suspend fun saveLastLocation(location: LocationPoint) {
+        context.dataStore.edit { preferences ->
+            preferences[latKey] = location.latitude.toString()
+            preferences[lngKey] = location.longitude.toString()
+        }
+    }
+
+    companion object {
+        private const val LOCATION_PREFERENCES_NAME = "location_preferences"
+        private const val LAT_KEY = "lat_key"
+        private const val LNG_KEY = "lng_key"
     }
 }

--- a/data/location/src/main/java/com/squirtles/data/location/di/LocationDiModule.kt
+++ b/data/location/src/main/java/com/squirtles/data/location/di/LocationDiModule.kt
@@ -1,10 +1,12 @@
 package com.squirtles.data.location.di
 
+import android.content.Context
 import com.squirtles.domain.location.LocalLocationRepository
 import com.squirtles.data.location.LocalLocationRepositoryImpl
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import javax.inject.Singleton
 
@@ -13,6 +15,6 @@ import javax.inject.Singleton
 object LocationDiModule {
     @Provides
     @Singleton
-    fun provideLocalLocationRepository(): LocalLocationRepository =
-        LocalLocationRepositoryImpl()
+    fun provideLocalLocationRepository(@ApplicationContext context: Context): LocalLocationRepository =
+        LocalLocationRepositoryImpl(context)
 }

--- a/domain/location/build.gradle.kts
+++ b/domain/location/build.gradle.kts
@@ -8,6 +8,7 @@ android {
 
 dependencies {
     implementation(libs.inject)
+    implementation(projects.core.model)
 
     testImplementation(libs.junit)
     androidTestImplementation(libs.bundles.test)

--- a/domain/location/build.gradle.kts
+++ b/domain/location/build.gradle.kts
@@ -1,15 +1,10 @@
 plugins {
-    alias(libs.plugins.musicroad.android.library)
-}
-
-android {
-    namespace = "com.squirtles.domain.location"
+    id(libs.plugins.musicroad.java.library.get().pluginId)
 }
 
 dependencies {
-    implementation(libs.inject)
     implementation(projects.core.model)
-
+    implementation(libs.kotlinx.coroutines.core)
+    
     testImplementation(libs.junit)
-    androidTestImplementation(libs.bundles.test)
 }

--- a/domain/location/src/main/java/com/squirtles/domain/location/LocalLocationRepository.kt
+++ b/domain/location/src/main/java/com/squirtles/domain/location/LocalLocationRepository.kt
@@ -1,10 +1,10 @@
 package com.squirtles.domain.location
 
-import android.location.Location
-import kotlinx.coroutines.flow.StateFlow
+import com.squirtles.core.model.LocationPoint
+import kotlinx.coroutines.flow.Flow
 
 interface LocalLocationRepository {
-    val lastLocation: StateFlow<Location?>
 
-    suspend fun saveCurrentLocation(geoLocation: Location)
+    fun readLastLocation(): Flow<LocationPoint?>
+    suspend fun saveLastLocation(location: LocationPoint)
 }

--- a/domain/location/src/main/java/com/squirtles/domain/location/usecase/GetLastLocationUseCase.kt
+++ b/domain/location/src/main/java/com/squirtles/domain/location/usecase/GetLastLocationUseCase.kt
@@ -6,5 +6,5 @@ import javax.inject.Inject
 class GetLastLocationUseCase @Inject constructor(
     private val localLocationRepository: LocalLocationRepository
 ) {
-    operator fun invoke() = localLocationRepository.lastLocation
+    operator fun invoke() = localLocationRepository.readLastLocation()
 }

--- a/domain/location/src/main/java/com/squirtles/domain/location/usecase/SaveLastLocationUseCase.kt
+++ b/domain/location/src/main/java/com/squirtles/domain/location/usecase/SaveLastLocationUseCase.kt
@@ -1,11 +1,12 @@
 package com.squirtles.domain.location.usecase
 
 import android.location.Location
+import com.squirtles.core.model.LocationPoint
 import com.squirtles.domain.location.LocalLocationRepository
 import javax.inject.Inject
 
 class SaveLastLocationUseCase @Inject constructor(
     private val localLocationRepository: LocalLocationRepository
 ) {
-    suspend operator fun invoke(location: Location) = localLocationRepository.saveCurrentLocation(location)
+    suspend operator fun invoke(location: LocationPoint) = localLocationRepository.saveLastLocation(location)
 }

--- a/domain/location/src/main/java/com/squirtles/domain/location/usecase/SaveLastLocationUseCase.kt
+++ b/domain/location/src/main/java/com/squirtles/domain/location/usecase/SaveLastLocationUseCase.kt
@@ -1,6 +1,5 @@
 package com.squirtles.domain.location.usecase
 
-import android.location.Location
 import com.squirtles.core.model.LocationPoint
 import com.squirtles.domain.location.LocalLocationRepository
 import javax.inject.Inject

--- a/feature/create/src/main/java/com/squirtles/feature/create/CreatePickViewModel.kt
+++ b/feature/create/src/main/java/com/squirtles/feature/create/CreatePickViewModel.kt
@@ -1,23 +1,22 @@
 package com.squirtles.feature.create
 
-import android.location.Location
 import android.util.Log
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
-import com.squirtles.domain.applemusic.usecase.FetchMusicVideoUseCase
-import com.squirtles.domain.location.usecase.GetLastLocationUseCase
 import com.squirtles.core.model.Creator
 import com.squirtles.core.model.LocationPoint
 import com.squirtles.core.model.Pick
 import com.squirtles.core.model.Song
 import com.squirtles.core.navigation.SearchRoute
+import com.squirtles.core.util.serializableType
+import com.squirtles.core.util.throttleFirst
+import com.squirtles.domain.applemusic.usecase.FetchMusicVideoUseCase
+import com.squirtles.domain.location.usecase.GetLastLocationUseCase
 import com.squirtles.domain.pick.usecase.CreatePickUseCase
 import com.squirtles.domain.user.usecase.FetchUserByIdUseCase
 import com.squirtles.domain.user.usecase.GetCurrentUidUseCase
-import com.squirtles.core.util.serializableType
-import com.squirtles.core.util.throttleFirst
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -45,7 +44,7 @@ class CreatePickViewModel @Inject constructor(
     private val _comment = MutableStateFlow("")
     val comment get() = _comment
 
-    private var lastLocation: Location? = null
+    private var lastLocation: LocationPoint? = null
     private val createPickClick = MutableSharedFlow<Unit>()
 
     init {

--- a/feature/map/src/main/java/com/squirtles/feature/map/MapScreen.kt
+++ b/feature/map/src/main/java/com/squirtles/feature/map/MapScreen.kt
@@ -1,5 +1,6 @@
 package com.squirtles.feature.map
 
+import android.content.Context
 import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -26,6 +27,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat.getString
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -33,6 +35,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.flowWithLifecycle
+import com.naver.maps.map.clustering.Clusterer
 import com.squirtles.core.account.AccountViewModel
 import com.squirtles.core.account.GoogleId
 import com.squirtles.core.common.ui.DoubleBackPressToExit
@@ -40,13 +43,49 @@ import com.squirtles.core.common.ui.MusicRoadPermissions.checkLocationPermission
 import com.squirtles.core.common.ui.SignInAlertDialog
 import com.squirtles.core.common.ui.VerticalSpacer
 import com.squirtles.core.common.ui.theme.Black
+import com.squirtles.core.common.ui.theme.MusicRoadTheme
+import com.squirtles.core.model.LocationPoint
+import com.squirtles.core.model.Pick
+import com.squirtles.core.model.PlayerState
 import com.squirtles.core.musicplayer.PlayerServiceViewModel
 import com.squirtles.feature.map.components.ClusterBottomSheet
 import com.squirtles.feature.map.components.InfoWindow
 import com.squirtles.feature.map.components.LoadingDialog
 import com.squirtles.feature.map.components.MapBottomNavBar
 import com.squirtles.feature.map.components.PickNotificationBanner
+import com.squirtles.feature.map.marker.MarkerKey
+import com.squirtles.feature.map.marker.buildClusterer
 import kotlinx.coroutines.launch
+
+private data class MapClickActions(
+    val onFavoriteClick: (String) -> Unit,
+    val onCenterClick: () -> Unit,
+    val onUserInfoClick: (String) -> Unit,
+    val onPickSummaryClick: (String) -> Unit,
+) {
+    companion object {
+        val preview = MapClickActions(
+            onFavoriteClick = {},
+            onCenterClick = {},
+            onUserInfoClick = {},
+            onPickSummaryClick = {},
+        )
+    }
+}
+
+private data class SignInActions(
+    val setShowSignInDialog: (Boolean) -> Unit,
+    val setSignInDialogDescription: (String) -> Unit,
+    val setSignInSuccess: ((String) -> Unit) -> Unit,
+) {
+    companion object {
+        val preview = SignInActions(
+            setShowSignInDialog = {},
+            setSignInDialogDescription = {},
+            setSignInSuccess = {}
+        )
+    }
+}
 
 @Composable
 fun MapScreen(
@@ -59,23 +98,25 @@ fun MapScreen(
     finishActivity: () -> Unit,
     accountViewModel: AccountViewModel = hiltViewModel()
 ) {
-    val nearPicks by mapViewModel.nearPicks.collectAsStateWithLifecycle()
-    val lastLocation by mapViewModel.lastLocation.collectAsStateWithLifecycle()
-
-    val clickedMarkerState by mapViewModel.clickedMarkerState.collectAsStateWithLifecycle()
-    val playerState by playerServiceViewModel.playerState.collectAsStateWithLifecycle()
-
     val context = LocalContext.current
     val lifecycleOwner = LocalLifecycleOwner.current
-    var showBottomSheet by remember { mutableStateOf(false) }
+
+    val nearPicks by mapViewModel.nearPicks.collectAsStateWithLifecycle()
+    val lastLocation by mapViewModel.lastLocation.collectAsStateWithLifecycle()
+    val clickedMarkerState by mapViewModel.clickedMarkerState.collectAsStateWithLifecycle()
+    val centerPoint by mapViewModel.centerPoint.collectAsStateWithLifecycle()
+    val playerState by playerServiceViewModel.playerState.collectAsStateWithLifecycle()
+
     var showLocationLoading by rememberSaveable { mutableStateOf(true) }
-    var isPlaying: Boolean by remember { mutableStateOf(false) }
 
     // Sign In Dialog
     var showSignInDialog by remember { mutableStateOf(false) }
     var signInDialogDescription by remember { mutableStateOf("") }
     var onSignInSuccess by remember { mutableStateOf<(String) -> Unit>({}) }
     var showLoadingIndicator by rememberSaveable { mutableStateOf(false) }
+
+    // permission
+    val hasPermission by remember { mutableStateOf(checkLocationPermission(context)) }
 
     DoubleBackPressToExit(!showLoadingIndicator) {
         finishActivity()
@@ -109,157 +150,61 @@ fun MapScreen(
         }
     }
 
-    LaunchedEffect(playerState) {
-        isPlaying = playerState.isPlaying
-    }
-
     LaunchedEffect(lastLocation) {
-        showLocationLoading = lastLocation == null
+        if (hasPermission) {
+            showLocationLoading = lastLocation == null
+        } else {
+            showLocationLoading = false
+        }
     }
 
-    Scaffold(
-        contentWindowInsets = WindowInsets.navigationBars
-    ) { innerPadding ->
+    MapScreenContent(
+        lastLocation = lastLocation,
+        picks = mapViewModel.picks,
+        nearPicks = nearPicks,
+        playerState = playerState,
+        clickedMarkerState = clickedMarkerState,
+        naverMapActions = NaverMapActions(
+            fetchPicksInBounds = mapViewModel::fetchPicksInBounds,
+            resetClickedMarkerState = mapViewModel::resetClickedMarkerState,
+            requestPickNotificationArea = mapViewModel::requestPickNotificationArea,
+            updateCurLocation = mapViewModel::updateCurLocation,
+            updateCenterLocation = mapViewModel::updateCenterLocation,
+            setLastCameraPosition = mapViewModel::setLastCameraPosition,
+            getLastCameraPosition = { mapViewModel.lastCameraPosition },
+        ),
+        mapClickActions = MapClickActions(
+            onFavoriteClick = onFavoriteClick,
+            onCenterClick = {
+                mapViewModel.saveCurLocationForced()
+                onCenterClick()
+            },
+            onUserInfoClick = onUserInfoClick,
+            onPickSummaryClick = onPickSummaryClick,
+        ),
+        signInActions = SignInActions(
+            setShowSignInDialog = { showSignInDialog = it },
+            setSignInDialogDescription = { signInDialogDescription = it },
+            setSignInSuccess = { onSignInSuccess = it }
+        ),
+        shuffleNextPick = playerServiceViewModel::shuffleNext,
+        calculateDistance = mapViewModel::calculateDistance,
+        getUid = mapViewModel::getUid,
+        centerPoint = centerPoint,
+        getClusterer = { buildClusterer(context, mapViewModel) },
+        hasPermission = { hasPermission }
+    )
+
+    if (showLocationLoading) {
         Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(innerPadding)
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center
         ) {
-            NaverMap(
-                mapViewModel = mapViewModel,
-                lastLocation = lastLocation,
+            LoadingDialog(
+                onCloseClick = {
+                    finishActivity()
+                }
             )
-
-            if (nearPicks.isNotEmpty()) {
-                PickNotificationBanner(
-                    nearPicks = nearPicks,
-                    isPlaying = isPlaying,
-                    onClick = {
-                        playerServiceViewModel.shuffleNext(
-                            if (nearPicks.size == 1) nearPicks.first()
-                            else nearPicks.filter { it.id != playerState.id }.random()
-                        )
-                    }
-                )
-            }
-
-            Column(
-                modifier = Modifier.fillMaxSize(),
-                verticalArrangement = Arrangement.Bottom,
-                horizontalAlignment = Alignment.CenterHorizontally
-            ) {
-                if (mapViewModel.lastCameraPosition != null &&
-                    clickedMarkerState.prevClickedMarker?.position == mapViewModel.lastCameraPosition?.target
-                ) {
-                    mapViewModel.resetClickedMarkerState(context)
-                } else {
-                    clickedMarkerState.prevClickedMarker?.let {
-                        if (clickedMarkerState.curPickId != null) { // 단말 마커 클릭 시
-                            showBottomSheet = false
-                            mapViewModel.picks[clickedMarkerState.curPickId]?.let { pick ->
-                                InfoWindow(
-                                    pick = pick,
-                                    uid = mapViewModel.getUid(),
-                                    navigateToPick = { pickId ->
-                                        onPickSummaryClick(pickId)
-                                    },
-                                    calculateDistance = { lat, lng ->
-                                        mapViewModel.calculateDistance(lat, lng).let { distance ->
-                                            when {
-                                                distance >= 1000.0 -> "%.1fkm".format(distance / 1000.0)
-                                                distance >= 0 -> "%.0fm".format(distance)
-                                                else -> ""
-                                            }
-                                        }
-                                    }
-                                )
-                            }
-                        } else { // 클러스터 마커 클릭 시
-                            showBottomSheet = true
-                        }
-                    }
-                }
-
-                VerticalSpacer(16)
-
-                MapBottomNavBar(
-                    modifier = Modifier.padding(bottom = 16.dp),
-                    isActivated = checkLocationPermission(context),
-                    onFavoriteClick = {
-                        mapViewModel.getUid()?.let { uid ->
-                            onFavoriteClick(uid)
-                        } ?: run {
-                            signInDialogDescription =
-                                getString(context, R.string.sign_in_dialog_title_favorite_picks)
-                            showSignInDialog = true
-                            onSignInSuccess = onFavoriteClick
-                        }
-                    },
-                    onCenterClick = {
-                        mapViewModel.getUid()?.let {
-                            onCenterClick()
-                            mapViewModel.saveCurLocationForced()
-                        } ?: run {
-                            signInDialogDescription =
-                                getString(context, R.string.sign_in_dialog_title_add_pick)
-                            showSignInDialog = true
-                            onSignInSuccess = {
-                                onCenterClick()
-                                mapViewModel.saveCurLocationForced()
-                            }
-                        }
-                    },
-                    onUserInfoClick = {
-                        mapViewModel.getUid()?.let { uid ->
-                            onUserInfoClick(uid)
-                        } ?: run {
-                            signInDialogDescription = getString(context, R.string.sign_in_dialog)
-                            showSignInDialog = true
-                            onSignInSuccess = onUserInfoClick
-                        }
-                    },
-                )
-            }
-
-            if (showBottomSheet) {
-                ClusterBottomSheet(
-                    onDismissRequest = {
-                        showBottomSheet = false
-                        mapViewModel.resetClickedMarkerState(context)
-                    },
-                    modifier = Modifier
-                        .fillMaxHeight()
-                        .padding(WindowInsets.statusBars.asPaddingValues()),
-                    clusterPickList = clickedMarkerState.clusterPickList,
-                    uid = mapViewModel.getUid(),
-                    calculateDistance = { lat, lng ->
-                        mapViewModel.calculateDistance(lat, lng).let { distance ->
-                            when {
-                                distance >= 1000.0 -> "%.1fkm".format(distance / 1000.0)
-                                distance >= 0 -> "%.0fm".format(distance)
-                                else -> ""
-                            }
-                        }
-
-                    },
-                    onClickItem = { pickId ->
-                        onPickSummaryClick(pickId)
-                    }
-                )
-            }
-
-            if (showLocationLoading) {
-                Box(
-                    modifier = Modifier.fillMaxSize(),
-                    contentAlignment = Alignment.Center
-                ) {
-                    LoadingDialog(
-                        onCloseClick = {
-                            finishActivity()
-                        }
-                    )
-                }
-            }
         }
     }
 
@@ -296,5 +241,189 @@ fun MapScreen(
         ) {
             CircularProgressIndicator()
         }
+    }
+}
+
+@Composable
+private fun MapScreenContent(
+    centerPoint: LocationPoint?,
+    lastLocation: LocationPoint?,
+    picks: Map<String, Pick>,
+    nearPicks: List<Pick>,
+    playerState: PlayerState,
+    clickedMarkerState: MarkerState,
+    naverMapActions: NaverMapActions,
+    mapClickActions: MapClickActions,
+    signInActions: SignInActions,
+    shuffleNextPick: (Pick) -> Unit,
+    calculateDistance: (Double, Double) -> Double,
+    getUid: () -> String?,
+    getClusterer: () -> Clusterer<MarkerKey>?,
+    hasPermission: () -> Boolean,
+) {
+    val context: Context = LocalContext.current
+
+    var showBottomSheet by remember { mutableStateOf(false) }
+
+    Scaffold(
+        contentWindowInsets = WindowInsets.navigationBars
+    ) { innerPadding ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+        ) {
+            NaverMap(
+                naverMapActions = naverMapActions,
+                centerPoint = centerPoint,
+                lastLocation = lastLocation,
+                hasPermission = hasPermission,
+                getClusterer = getClusterer
+            )
+
+            if (nearPicks.isNotEmpty()) {
+                PickNotificationBanner(
+                    nearPicks = nearPicks,
+                    isPlaying = playerState.isPlaying,
+                    onClick = {
+                        shuffleNextPick(
+                            if (nearPicks.size == 1) nearPicks.first()
+                            else nearPicks.filter { it.id != playerState.id }.random()
+                        )
+                    }
+                )
+            }
+
+            Column(
+                modifier = Modifier.fillMaxSize(),
+                verticalArrangement = Arrangement.Bottom,
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                val lastCameraPosition = naverMapActions.getLastCameraPosition()
+                if (lastCameraPosition != null &&
+                    clickedMarkerState.prevClickedMarker?.position == lastCameraPosition.target
+                ) {
+                    naverMapActions.resetClickedMarkerState(context)
+                } else {
+                    clickedMarkerState.prevClickedMarker?.let {
+                        if (clickedMarkerState.curPickId != null) { // 단말 마커 클릭 시
+                            showBottomSheet = false
+                            picks[clickedMarkerState.curPickId]?.let { pick ->
+                                InfoWindow(
+                                    pick = pick,
+                                    uid = getUid(),
+                                    navigateToPick = { pickId ->
+                                        mapClickActions.onPickSummaryClick(pickId)
+                                    },
+                                    calculateDistance = { lat, lng ->
+                                        calculateDistance(lat, lng).let { distance ->
+                                            when {
+                                                distance >= 1000.0 -> "%.1fkm".format(distance / 1000.0)
+                                                distance >= 0 -> "%.0fm".format(distance)
+                                                else -> ""
+                                            }
+                                        }
+                                    }
+                                )
+                            }
+                        } else { // 클러스터 마커 클릭 시
+                            showBottomSheet = true
+                        }
+                    }
+                }
+
+                VerticalSpacer(16)
+
+                MapBottomNavBar(
+                    modifier = Modifier.padding(bottom = 16.dp),
+                    isActivated = checkLocationPermission(context),
+                    onFavoriteClick = {
+                        getUid()?.let { uid ->
+                            mapClickActions.onFavoriteClick(uid)
+                        } ?: run {
+                            signInActions.setSignInDialogDescription(
+                                getString(context, R.string.sign_in_dialog_title_favorite_picks)
+                            )
+                            signInActions.setShowSignInDialog(true)
+                            signInActions.setSignInSuccess(mapClickActions.onFavoriteClick)
+                        }
+                    },
+                    onCenterClick = {
+                        getUid()?.let {
+                            mapClickActions.onCenterClick()
+                        } ?: run {
+                            signInActions.setSignInDialogDescription(
+                                getString(context, R.string.sign_in_dialog_title_add_pick)
+                            )
+                            signInActions.setShowSignInDialog(true)
+                            signInActions.setSignInSuccess {
+                                mapClickActions.onCenterClick()
+                            }
+                        }
+                    },
+                    onUserInfoClick = {
+                        getUid()?.let { uid ->
+                            mapClickActions.onUserInfoClick(uid)
+                        } ?: run {
+                            signInActions.setSignInDialogDescription(
+                                getString(context, R.string.sign_in_dialog)
+                            )
+                            signInActions.setShowSignInDialog(true)
+                            signInActions.setSignInSuccess(mapClickActions.onUserInfoClick)
+                        }
+                    },
+                )
+            }
+
+            if (showBottomSheet) {
+                ClusterBottomSheet(
+                    onDismissRequest = {
+                        showBottomSheet = false
+                        naverMapActions.resetClickedMarkerState(context)
+                    },
+                    modifier = Modifier
+                        .fillMaxHeight()
+                        .padding(WindowInsets.statusBars.asPaddingValues()),
+                    clusterPickList = clickedMarkerState.clusterPickList,
+                    uid = getUid(),
+                    calculateDistance = { lat, lng ->
+                        calculateDistance(lat, lng).let { distance ->
+                            when {
+                                distance >= 1000.0 -> "%.1fkm".format(distance / 1000.0)
+                                distance >= 0 -> "%.0fm".format(distance)
+                                else -> ""
+                            }
+                        }
+
+                    },
+                    onClickItem = { pickId ->
+                        mapClickActions.onPickSummaryClick(pickId)
+                    }
+                )
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+fun MapScreenPreview() {
+    MusicRoadTheme {
+        MapScreenContent(
+            mapClickActions = MapClickActions.preview,
+            signInActions = SignInActions.preview,
+            naverMapActions = NaverMapActions.preview,
+            lastLocation = null,
+            picks = emptyMap(),
+            nearPicks = emptyList(),
+            playerState = PlayerState(),
+            clickedMarkerState = MarkerState(),
+            shuffleNextPick = { },
+            calculateDistance = { _, _ -> 0.0 },
+            getUid = { "" },
+            centerPoint = null,
+            getClusterer = { null },
+            hasPermission = { true }
+        )
     }
 }

--- a/feature/map/src/main/java/com/squirtles/feature/map/MapScreen.kt
+++ b/feature/map/src/main/java/com/squirtles/feature/map/MapScreen.kt
@@ -1,6 +1,6 @@
 package com.squirtles.feature.map
 
-import android.content.Context
+import android.util.Log
 import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -27,7 +27,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat.getString
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -35,7 +34,6 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.flowWithLifecycle
-import com.naver.maps.map.clustering.Clusterer
 import com.squirtles.core.account.AccountViewModel
 import com.squirtles.core.account.GoogleId
 import com.squirtles.core.common.ui.DoubleBackPressToExit
@@ -43,49 +41,13 @@ import com.squirtles.core.common.ui.MusicRoadPermissions.checkLocationPermission
 import com.squirtles.core.common.ui.SignInAlertDialog
 import com.squirtles.core.common.ui.VerticalSpacer
 import com.squirtles.core.common.ui.theme.Black
-import com.squirtles.core.common.ui.theme.MusicRoadTheme
-import com.squirtles.core.model.LocationPoint
-import com.squirtles.core.model.Pick
-import com.squirtles.core.model.PlayerState
 import com.squirtles.core.musicplayer.PlayerServiceViewModel
 import com.squirtles.feature.map.components.ClusterBottomSheet
 import com.squirtles.feature.map.components.InfoWindow
 import com.squirtles.feature.map.components.LoadingDialog
 import com.squirtles.feature.map.components.MapBottomNavBar
 import com.squirtles.feature.map.components.PickNotificationBanner
-import com.squirtles.feature.map.marker.MarkerKey
-import com.squirtles.feature.map.marker.buildClusterer
 import kotlinx.coroutines.launch
-
-private data class MapClickActions(
-    val onFavoriteClick: (String) -> Unit,
-    val onCenterClick: () -> Unit,
-    val onUserInfoClick: (String) -> Unit,
-    val onPickSummaryClick: (String) -> Unit,
-) {
-    companion object {
-        val preview = MapClickActions(
-            onFavoriteClick = {},
-            onCenterClick = {},
-            onUserInfoClick = {},
-            onPickSummaryClick = {},
-        )
-    }
-}
-
-private data class SignInActions(
-    val setShowSignInDialog: (Boolean) -> Unit,
-    val setSignInDialogDescription: (String) -> Unit,
-    val setSignInSuccess: ((String) -> Unit) -> Unit,
-) {
-    companion object {
-        val preview = SignInActions(
-            setShowSignInDialog = {},
-            setSignInDialogDescription = {},
-            setSignInSuccess = {}
-        )
-    }
-}
 
 @Composable
 fun MapScreen(
@@ -98,15 +60,15 @@ fun MapScreen(
     finishActivity: () -> Unit,
     accountViewModel: AccountViewModel = hiltViewModel()
 ) {
-    val context = LocalContext.current
-    val lifecycleOwner = LocalLifecycleOwner.current
-
     val nearPicks by mapViewModel.nearPicks.collectAsStateWithLifecycle()
     val lastLocation by mapViewModel.lastLocation.collectAsStateWithLifecycle()
+
     val clickedMarkerState by mapViewModel.clickedMarkerState.collectAsStateWithLifecycle()
-    val centerPoint by mapViewModel.centerPoint.collectAsStateWithLifecycle()
     val playerState by playerServiceViewModel.playerState.collectAsStateWithLifecycle()
 
+    val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
+    var showBottomSheet by remember { mutableStateOf(false) }
     var showLocationLoading by rememberSaveable { mutableStateOf(true) }
 
     // Sign In Dialog
@@ -114,9 +76,6 @@ fun MapScreen(
     var signInDialogDescription by remember { mutableStateOf("") }
     var onSignInSuccess by remember { mutableStateOf<(String) -> Unit>({}) }
     var showLoadingIndicator by rememberSaveable { mutableStateOf(false) }
-
-    // permission
-    val hasPermission by remember { mutableStateOf(checkLocationPermission(context)) }
 
     DoubleBackPressToExit(!showLoadingIndicator) {
         finishActivity()
@@ -151,60 +110,152 @@ fun MapScreen(
     }
 
     LaunchedEffect(lastLocation) {
-        if (hasPermission) {
-            showLocationLoading = lastLocation == null
-        } else {
-            showLocationLoading = false
-        }
+        showLocationLoading = lastLocation == null
     }
 
-    MapScreenContent(
-        lastLocation = lastLocation,
-        picks = mapViewModel.picks,
-        nearPicks = nearPicks,
-        playerState = playerState,
-        clickedMarkerState = clickedMarkerState,
-        naverMapActions = NaverMapActions(
-            fetchPicksInBounds = mapViewModel::fetchPicksInBounds,
-            resetClickedMarkerState = mapViewModel::resetClickedMarkerState,
-            requestPickNotificationArea = mapViewModel::requestPickNotificationArea,
-            updateCurLocation = mapViewModel::updateCurLocation,
-            updateCenterLocation = mapViewModel::updateCenterLocation,
-            setLastCameraPosition = mapViewModel::setLastCameraPosition,
-            getLastCameraPosition = { mapViewModel.lastCameraPosition },
-        ),
-        mapClickActions = MapClickActions(
-            onFavoriteClick = onFavoriteClick,
-            onCenterClick = {
-                mapViewModel.saveCurLocationForced()
-                onCenterClick()
-            },
-            onUserInfoClick = onUserInfoClick,
-            onPickSummaryClick = onPickSummaryClick,
-        ),
-        signInActions = SignInActions(
-            setShowSignInDialog = { showSignInDialog = it },
-            setSignInDialogDescription = { signInDialogDescription = it },
-            setSignInSuccess = { onSignInSuccess = it }
-        ),
-        shuffleNextPick = playerServiceViewModel::shuffleNext,
-        calculateDistance = mapViewModel::calculateDistance,
-        getUid = mapViewModel::getUid,
-        centerPoint = centerPoint,
-        getClusterer = { buildClusterer(context, mapViewModel) },
-        hasPermission = { hasPermission }
-    )
-
-    if (showLocationLoading) {
+    Scaffold(
+        contentWindowInsets = WindowInsets.navigationBars
+    ) { innerPadding ->
         Box(
-            modifier = Modifier.fillMaxSize(),
-            contentAlignment = Alignment.Center
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
         ) {
-            LoadingDialog(
-                onCloseClick = {
-                    finishActivity()
-                }
+            NaverMap(
+                mapViewModel = mapViewModel,
+                lastLocation = lastLocation,
             )
+
+            if (nearPicks.isNotEmpty()) {
+                PickNotificationBanner(
+                    nearPicks = nearPicks,
+                    isPlaying = playerState.isPlaying,
+                    onClick = {
+                        playerServiceViewModel.shuffleNext(
+                            if (nearPicks.size == 1) nearPicks.first()
+                            else nearPicks.filter { it.id != playerState.id }.random()
+                        )
+                    }
+                )
+            }
+
+            Column(
+                modifier = Modifier.fillMaxSize(),
+                verticalArrangement = Arrangement.Bottom,
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                if (mapViewModel.lastCameraPosition != null &&
+                    clickedMarkerState.prevClickedMarker?.position == mapViewModel.lastCameraPosition?.target
+                ) {
+                    mapViewModel.resetClickedMarkerState(context)
+                } else {
+                    clickedMarkerState.prevClickedMarker?.let {
+                        if (clickedMarkerState.curPickId != null) { // 단말 마커 클릭 시
+                            showBottomSheet = false
+                            mapViewModel.picks[clickedMarkerState.curPickId]?.let { pick ->
+                                InfoWindow(
+                                    pick = pick,
+                                    uid = mapViewModel.getUid(),
+                                    navigateToPick = { pickId ->
+                                        onPickSummaryClick(pickId)
+                                    },
+                                    calculateDistance = { lat, lng ->
+                                        mapViewModel.calculateDistance(lat, lng).let { distance ->
+                                            when {
+                                                distance >= 1000.0 -> "%.1fkm".format(distance / 1000.0)
+                                                distance >= 0 -> "%.0fm".format(distance)
+                                                else -> ""
+                                            }
+                                        }
+                                    }
+                                )
+                            }
+                        } else { // 클러스터 마커 클릭 시
+                            showBottomSheet = true
+                        }
+                    }
+                }
+
+                VerticalSpacer(16)
+
+                MapBottomNavBar(
+                    modifier = Modifier.padding(bottom = 16.dp),
+                    isActivated = checkLocationPermission(context),
+                    onFavoriteClick = {
+                        mapViewModel.getUid()?.let { uid ->
+                            onFavoriteClick(uid)
+                        } ?: run {
+                            signInDialogDescription =
+                                getString(context, R.string.sign_in_dialog_title_favorite_picks)
+                            showSignInDialog = true
+                            onSignInSuccess = onFavoriteClick
+                        }
+                    },
+                    onCenterClick = {
+                        mapViewModel.getUid()?.let {
+                            onCenterClick()
+                            mapViewModel.saveCurLocationForced()
+                        } ?: run {
+                            signInDialogDescription =
+                                getString(context, R.string.sign_in_dialog_title_add_pick)
+                            showSignInDialog = true
+                            onSignInSuccess = {
+                                onCenterClick()
+                                mapViewModel.saveCurLocationForced()
+                            }
+                        }
+                    },
+                    onUserInfoClick = {
+                        mapViewModel.getUid()?.let { uid ->
+                            onUserInfoClick(uid)
+                        } ?: run {
+                            signInDialogDescription = getString(context, R.string.sign_in_dialog)
+                            showSignInDialog = true
+                            onSignInSuccess = onUserInfoClick
+                        }
+                    },
+                )
+            }
+
+            if (showBottomSheet) {
+                ClusterBottomSheet(
+                    onDismissRequest = {
+                        showBottomSheet = false
+                        mapViewModel.resetClickedMarkerState(context)
+                    },
+                    modifier = Modifier
+                        .fillMaxHeight()
+                        .padding(WindowInsets.statusBars.asPaddingValues()),
+                    clusterPickList = clickedMarkerState.clusterPickList,
+                    uid = mapViewModel.getUid(),
+                    calculateDistance = { lat, lng ->
+                        mapViewModel.calculateDistance(lat, lng).let { distance ->
+                            when {
+                                distance >= 1000.0 -> "%.1fkm".format(distance / 1000.0)
+                                distance >= 0 -> "%.0fm".format(distance)
+                                else -> ""
+                            }
+                        }
+
+                    },
+                    onClickItem = { pickId ->
+                        onPickSummaryClick(pickId)
+                    }
+                )
+            }
+
+            if (showLocationLoading) {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    LoadingDialog(
+                        onCloseClick = {
+                            finishActivity()
+                        }
+                    )
+                }
+            }
         }
     }
 
@@ -241,189 +292,5 @@ fun MapScreen(
         ) {
             CircularProgressIndicator()
         }
-    }
-}
-
-@Composable
-private fun MapScreenContent(
-    centerPoint: LocationPoint?,
-    lastLocation: LocationPoint?,
-    picks: Map<String, Pick>,
-    nearPicks: List<Pick>,
-    playerState: PlayerState,
-    clickedMarkerState: MarkerState,
-    naverMapActions: NaverMapActions,
-    mapClickActions: MapClickActions,
-    signInActions: SignInActions,
-    shuffleNextPick: (Pick) -> Unit,
-    calculateDistance: (Double, Double) -> Double,
-    getUid: () -> String?,
-    getClusterer: () -> Clusterer<MarkerKey>?,
-    hasPermission: () -> Boolean,
-) {
-    val context: Context = LocalContext.current
-
-    var showBottomSheet by remember { mutableStateOf(false) }
-
-    Scaffold(
-        contentWindowInsets = WindowInsets.navigationBars
-    ) { innerPadding ->
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(innerPadding)
-        ) {
-            NaverMap(
-                naverMapActions = naverMapActions,
-                centerPoint = centerPoint,
-                lastLocation = lastLocation,
-                hasPermission = hasPermission,
-                getClusterer = getClusterer
-            )
-
-            if (nearPicks.isNotEmpty()) {
-                PickNotificationBanner(
-                    nearPicks = nearPicks,
-                    isPlaying = playerState.isPlaying,
-                    onClick = {
-                        shuffleNextPick(
-                            if (nearPicks.size == 1) nearPicks.first()
-                            else nearPicks.filter { it.id != playerState.id }.random()
-                        )
-                    }
-                )
-            }
-
-            Column(
-                modifier = Modifier.fillMaxSize(),
-                verticalArrangement = Arrangement.Bottom,
-                horizontalAlignment = Alignment.CenterHorizontally
-            ) {
-                val lastCameraPosition = naverMapActions.getLastCameraPosition()
-                if (lastCameraPosition != null &&
-                    clickedMarkerState.prevClickedMarker?.position == lastCameraPosition.target
-                ) {
-                    naverMapActions.resetClickedMarkerState(context)
-                } else {
-                    clickedMarkerState.prevClickedMarker?.let {
-                        if (clickedMarkerState.curPickId != null) { // 단말 마커 클릭 시
-                            showBottomSheet = false
-                            picks[clickedMarkerState.curPickId]?.let { pick ->
-                                InfoWindow(
-                                    pick = pick,
-                                    uid = getUid(),
-                                    navigateToPick = { pickId ->
-                                        mapClickActions.onPickSummaryClick(pickId)
-                                    },
-                                    calculateDistance = { lat, lng ->
-                                        calculateDistance(lat, lng).let { distance ->
-                                            when {
-                                                distance >= 1000.0 -> "%.1fkm".format(distance / 1000.0)
-                                                distance >= 0 -> "%.0fm".format(distance)
-                                                else -> ""
-                                            }
-                                        }
-                                    }
-                                )
-                            }
-                        } else { // 클러스터 마커 클릭 시
-                            showBottomSheet = true
-                        }
-                    }
-                }
-
-                VerticalSpacer(16)
-
-                MapBottomNavBar(
-                    modifier = Modifier.padding(bottom = 16.dp),
-                    isActivated = checkLocationPermission(context),
-                    onFavoriteClick = {
-                        getUid()?.let { uid ->
-                            mapClickActions.onFavoriteClick(uid)
-                        } ?: run {
-                            signInActions.setSignInDialogDescription(
-                                getString(context, R.string.sign_in_dialog_title_favorite_picks)
-                            )
-                            signInActions.setShowSignInDialog(true)
-                            signInActions.setSignInSuccess(mapClickActions.onFavoriteClick)
-                        }
-                    },
-                    onCenterClick = {
-                        getUid()?.let {
-                            mapClickActions.onCenterClick()
-                        } ?: run {
-                            signInActions.setSignInDialogDescription(
-                                getString(context, R.string.sign_in_dialog_title_add_pick)
-                            )
-                            signInActions.setShowSignInDialog(true)
-                            signInActions.setSignInSuccess {
-                                mapClickActions.onCenterClick()
-                            }
-                        }
-                    },
-                    onUserInfoClick = {
-                        getUid()?.let { uid ->
-                            mapClickActions.onUserInfoClick(uid)
-                        } ?: run {
-                            signInActions.setSignInDialogDescription(
-                                getString(context, R.string.sign_in_dialog)
-                            )
-                            signInActions.setShowSignInDialog(true)
-                            signInActions.setSignInSuccess(mapClickActions.onUserInfoClick)
-                        }
-                    },
-                )
-            }
-
-            if (showBottomSheet) {
-                ClusterBottomSheet(
-                    onDismissRequest = {
-                        showBottomSheet = false
-                        naverMapActions.resetClickedMarkerState(context)
-                    },
-                    modifier = Modifier
-                        .fillMaxHeight()
-                        .padding(WindowInsets.statusBars.asPaddingValues()),
-                    clusterPickList = clickedMarkerState.clusterPickList,
-                    uid = getUid(),
-                    calculateDistance = { lat, lng ->
-                        calculateDistance(lat, lng).let { distance ->
-                            when {
-                                distance >= 1000.0 -> "%.1fkm".format(distance / 1000.0)
-                                distance >= 0 -> "%.0fm".format(distance)
-                                else -> ""
-                            }
-                        }
-
-                    },
-                    onClickItem = { pickId ->
-                        mapClickActions.onPickSummaryClick(pickId)
-                    }
-                )
-            }
-        }
-    }
-}
-
-@Preview
-@Composable
-fun MapScreenPreview() {
-    MusicRoadTheme {
-        MapScreenContent(
-            mapClickActions = MapClickActions.preview,
-            signInActions = SignInActions.preview,
-            naverMapActions = NaverMapActions.preview,
-            lastLocation = null,
-            picks = emptyMap(),
-            nearPicks = emptyList(),
-            playerState = PlayerState(),
-            clickedMarkerState = MarkerState(),
-            shuffleNextPick = { },
-            calculateDistance = { _, _ -> 0.0 },
-            getUid = { "" },
-            centerPoint = null,
-            getClusterer = { null },
-            hasPermission = { true }
-        )
     }
 }

--- a/feature/map/src/main/java/com/squirtles/feature/map/MapScreen.kt
+++ b/feature/map/src/main/java/com/squirtles/feature/map/MapScreen.kt
@@ -36,6 +36,7 @@ import androidx.lifecycle.flowWithLifecycle
 import com.squirtles.core.account.AccountViewModel
 import com.squirtles.core.account.GoogleId
 import com.squirtles.core.common.ui.DoubleBackPressToExit
+import com.squirtles.core.common.ui.MusicRoadPermissions.checkLocationPermission
 import com.squirtles.core.common.ui.SignInAlertDialog
 import com.squirtles.core.common.ui.VerticalSpacer
 import com.squirtles.core.common.ui.theme.Black
@@ -100,7 +101,10 @@ fun MapScreen(
             mapViewModel.fetchPicksErrorToast
                 .flowWithLifecycle(lifecycleOwner.lifecycle, Lifecycle.State.STARTED)
                 .collect {
-                    Toast.makeText(context, context.getString(R.string.error_message_fetch_picks_in_bounds), Toast.LENGTH_SHORT).show()
+                    Toast.makeText(
+                        context,
+                        context.getString(R.string.error_message_fetch_picks_in_bounds), Toast.LENGTH_SHORT
+                    ).show()
                 }
         }
     }
@@ -123,7 +127,7 @@ fun MapScreen(
         ) {
             NaverMap(
                 mapViewModel = mapViewModel,
-                lastLocation = lastLocation
+                lastLocation = lastLocation,
             )
 
             if (nearPicks.isNotEmpty()) {
@@ -180,7 +184,7 @@ fun MapScreen(
 
                 MapBottomNavBar(
                     modifier = Modifier.padding(bottom = 16.dp),
-                    lastLocation = lastLocation,
+                    isActivated = checkLocationPermission(context),
                     onFavoriteClick = {
                         mapViewModel.getUid()?.let { uid ->
                             onFavoriteClick(uid)
@@ -213,7 +217,7 @@ fun MapScreen(
                             showSignInDialog = true
                             onSignInSuccess = onUserInfoClick
                         }
-                    }
+                    },
                 )
             }
 

--- a/feature/map/src/main/java/com/squirtles/feature/map/MapScreen.kt
+++ b/feature/map/src/main/java/com/squirtles/feature/map/MapScreen.kt
@@ -76,6 +76,9 @@ fun MapScreen(
     var onSignInSuccess by remember { mutableStateOf<(String) -> Unit>({}) }
     var showLoadingIndicator by rememberSaveable { mutableStateOf(false) }
 
+    // permission
+    val hasPermission by remember { mutableStateOf(checkLocationPermission(context)) }
+
     DoubleBackPressToExit(!showLoadingIndicator) {
         finishActivity()
     }
@@ -109,9 +112,9 @@ fun MapScreen(
     }
 
     LaunchedEffect(lastLocation) {
-        showLocationLoading = lastLocation == null
+        showLocationLoading = if (hasPermission) lastLocation == null else false
     }
-
+    
     Scaffold(
         contentWindowInsets = WindowInsets.navigationBars
     ) { innerPadding ->
@@ -121,6 +124,7 @@ fun MapScreen(
                 .padding(innerPadding)
         ) {
             NaverMap(
+                hasPermission = hasPermission,
                 mapViewModel = mapViewModel,
                 lastLocation = lastLocation,
             )

--- a/feature/map/src/main/java/com/squirtles/feature/map/MapScreen.kt
+++ b/feature/map/src/main/java/com/squirtles/feature/map/MapScreen.kt
@@ -1,6 +1,5 @@
 package com.squirtles.feature.map
 
-import android.util.Log
 import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -145,11 +144,11 @@ fun MapScreen(
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
                 if (mapViewModel.lastCameraPosition != null &&
-                    clickedMarkerState.prevClickedMarker?.position == mapViewModel.lastCameraPosition?.target
+                    clickedMarkerState.lastClickedMarker?.position == mapViewModel.lastCameraPosition?.target
                 ) {
                     mapViewModel.resetClickedMarkerState(context)
                 } else {
-                    clickedMarkerState.prevClickedMarker?.let {
+                    clickedMarkerState.lastClickedMarker?.let {
                         if (clickedMarkerState.curPickId != null) { // 단말 마커 클릭 시
                             showBottomSheet = false
                             mapViewModel.picks[clickedMarkerState.curPickId]?.let { pick ->

--- a/feature/map/src/main/java/com/squirtles/feature/map/MapViewModel.kt
+++ b/feature/map/src/main/java/com/squirtles/feature/map/MapViewModel.kt
@@ -1,26 +1,28 @@
 package com.squirtles.feature.map
 
 import android.content.Context
-import android.location.Location
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.naver.maps.geometry.LatLng
 import com.naver.maps.map.CameraPosition
 import com.naver.maps.map.clustering.Clusterer
 import com.naver.maps.map.overlay.Marker
+import com.squirtles.core.model.LocationPoint
+import com.squirtles.core.model.Pick
 import com.squirtles.domain.location.usecase.GetLastLocationUseCase
 import com.squirtles.domain.location.usecase.SaveLastLocationUseCase
-import com.squirtles.feature.map.marker.MarkerKey
-import com.squirtles.core.model.Pick
 import com.squirtles.domain.pick.usecase.FetchPickUseCase
 import com.squirtles.domain.user.usecase.GetCurrentUidUseCase
+import com.squirtles.feature.map.marker.MarkerKey
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -38,8 +40,8 @@ class MapViewModel @Inject constructor(
     private val getCurrentUidUseCase: GetCurrentUidUseCase
 ) : ViewModel() {
 
-    private val _centerLatLng: MutableStateFlow<LatLng?> = MutableStateFlow(null)
-    val centerLatLng = _centerLatLng.asStateFlow()
+    private val _centerPoint: MutableStateFlow<LocationPoint?> = MutableStateFlow(null)
+    val centerPoint = _centerPoint.asStateFlow()
 
     private var _lastCameraPosition: CameraPosition? = null
     val lastCameraPosition get() = _lastCameraPosition
@@ -57,12 +59,15 @@ class MapViewModel @Inject constructor(
     val fetchPicksErrorToast = _fetchPicksErrorToast.asSharedFlow()
 
     // FIXME : 네이버맵의 LocationChangeListener에서 실시간으로 변하는 위치 정보 -> 더 나은 방법이 있으면 고쳐주세요
-    private var _currentLocation: Location? = null
-    val curLocation get() = _currentLocation
+    private var _currentLocation: LocationPoint? = null
 
     // LocalDataSource에 저장되는 위치 정보
     // Firestore 데이터 쿼리 작업 최소화 및 위치데이터 공유 용도
-    val lastLocation: StateFlow<Location?> = getLastLocationUseCase()
+    val lastLocation: StateFlow<LocationPoint?> = getLastLocationUseCase().stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(3000L),
+        initialValue = null
+    )
 
     fun getUid() = getCurrentUidUseCase()
 
@@ -70,17 +75,18 @@ class MapViewModel @Inject constructor(
         _lastCameraPosition = cameraPosition
     }
 
-    fun updateCurLocation(location: Location) {
-        _currentLocation = location
+    fun updateCurLocation(lat: Double, lng: Double) {
+        val point = LocationPoint(lat, lng)
+        _currentLocation = point
 
         if (lastLocation.value == null
-            || calculateDistance(location.latitude, location.longitude) > 5.0
+            || calculateDistance(lat, lng) > 5.0
         ) {
-            saveCurLocation(location)
+            saveCurLocation(point)
         }
     }
 
-    private fun saveCurLocation(location: Location) {
+    private fun saveCurLocation(location: LocationPoint) {
         viewModelScope.launch {
             saveLastLocationUseCase(location)
         }
@@ -95,19 +101,16 @@ class MapViewModel @Inject constructor(
     fun calculateDistance(
         lat: Double,
         lng: Double,
-        from: Location? = lastLocation.value,
+        from: LocationPoint? = lastLocation.value,
     ): Double {
         return from?.let {
-            val location = Location("pickLocation").apply {
-                latitude = lat
-                longitude = lng
-            }
-            from.distanceTo(location).toDouble()
+            val pickLatLng = LatLng(lat, lng)
+            LatLng(from.latitude, from.longitude).distanceTo(pickLatLng)
         } ?: -1.0
     }
 
-    fun updateCenterLatLng(latLng: LatLng) {
-        _centerLatLng.value = latLng
+    fun updateCenterLatLng(lat: Double, lng: Double) {
+        _centerPoint.value = LocationPoint(lat, lng)
     }
 
     // FIXME: 인자로 Context 받는 것 수정하기
@@ -145,10 +148,11 @@ class MapViewModel @Inject constructor(
         }
     }
 
+    // 유저 화면 내 픽 불러오기
     fun fetchPicksInBounds(leftTop: LatLng, clusterer: Clusterer<MarkerKey>?) {
         viewModelScope.launch {
-            _centerLatLng.value?.run {
-                val radiusInM = leftTop.distanceTo(this)
+            _centerPoint.value?.run {
+                val radiusInM = leftTop.distanceTo(LatLng(this.latitude, this.longitude))
                 fetchPickUseCase(this.latitude, this.longitude, radiusInM)
                     .catch {
                         _fetchPicksErrorToast.emit(Unit)
@@ -174,9 +178,10 @@ class MapViewModel @Inject constructor(
         }
     }
 
-    fun requestPickNotificationArea(location: Location, notiRadius: Double) {
+    // CircleOverlay 내 픽 불러오기
+    fun requestPickNotificationArea(location: LocationPoint, notifyRadius: Double) {
         viewModelScope.launch {
-            fetchPickUseCase(location.latitude, location.longitude, notiRadius)
+            fetchPickUseCase(location.latitude, location.longitude, notifyRadius)
                 .catch {
                     _fetchPicksErrorToast.emit(Unit)
                 }

--- a/feature/map/src/main/java/com/squirtles/feature/map/MapViewModel.kt
+++ b/feature/map/src/main/java/com/squirtles/feature/map/MapViewModel.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 data class MarkerState(
-    val prevClickedMarker: Marker? = null, // 이전에 클릭한 마커(클러스터 마커 & 단말 마커)
+    val lastClickedMarker: Marker? = null, // 이전에 클릭한 마커(클러스터 마커 & 단말 마커)
     val clusterPickList: List<Pick>? = null, // 클러스터 마커의 픽 정보
     val curPickId: String? = null // 현재 선택한 마커의 pick id
 )
@@ -117,7 +117,7 @@ class MapViewModel @Inject constructor(
     fun setClickedMarker(context: Context, marker: Marker) {
         viewModelScope.launch {
             marker.toggleSizeByClick(context, true)
-            _clickedMarkerState.emit(_clickedMarkerState.value.copy(prevClickedMarker = marker))
+            _clickedMarkerState.emit(_clickedMarkerState.value.copy(lastClickedMarker = marker))
         }
     }
 
@@ -128,10 +128,10 @@ class MapViewModel @Inject constructor(
         pickId: String? = null
     ) {
         viewModelScope.launch {
-            val prevClickedMarker = _clickedMarkerState.value.prevClickedMarker
+            val lastClickedMarker = _clickedMarkerState.value.lastClickedMarker
             // 클릭한 마커와 클릭되어 있는 마커가 다를 때만 크기 변경
-            if (prevClickedMarker != marker) {
-                prevClickedMarker?.toggleSizeByClick(context, false)
+            if (lastClickedMarker != marker) {
+                lastClickedMarker?.toggleSizeByClick(context, false)
                 marker.toggleSizeByClick(context, true)
             }
 
@@ -142,8 +142,8 @@ class MapViewModel @Inject constructor(
 
     fun resetClickedMarkerState(context: Context) {
         viewModelScope.launch {
-            val prevClickedMarker = _clickedMarkerState.value.prevClickedMarker
-            prevClickedMarker?.toggleSizeByClick(context, false)
+            val lastClickedMarker = _clickedMarkerState.value.lastClickedMarker
+            lastClickedMarker?.toggleSizeByClick(context, false)
             _clickedMarkerState.emit(MarkerState(null, null, null))
         }
     }

--- a/feature/map/src/main/java/com/squirtles/feature/map/MapViewModel.kt
+++ b/feature/map/src/main/java/com/squirtles/feature/map/MapViewModel.kt
@@ -121,7 +121,7 @@ class MapViewModel @Inject constructor(
         }
     }
 
-    fun setClickedMarkerState(
+    fun updateClickedMarkerState(
         context: Context,
         marker: Marker,
         clusterTag: String? = null,

--- a/feature/map/src/main/java/com/squirtles/feature/map/MapViewModel.kt
+++ b/feature/map/src/main/java/com/squirtles/feature/map/MapViewModel.kt
@@ -109,7 +109,7 @@ class MapViewModel @Inject constructor(
         } ?: -1.0
     }
 
-    fun updateCenterLatLng(lat: Double, lng: Double) {
+    fun updateCenterLocation(lat: Double, lng: Double) {
         _centerPoint.value = LocationPoint(lat, lng)
     }
 
@@ -179,9 +179,9 @@ class MapViewModel @Inject constructor(
     }
 
     // CircleOverlay 내 픽 불러오기
-    fun requestPickNotificationArea(location: LocationPoint, notifyRadius: Double) {
+    fun requestPickNotificationArea(lat: Double, lng: Double, notifyRadius: Double) {
         viewModelScope.launch {
-            fetchPickUseCase(location.latitude, location.longitude, notifyRadius)
+            fetchPickUseCase(lat, lng, notifyRadius)
                 .catch {
                     _fetchPicksErrorToast.emit(Unit)
                 }

--- a/feature/map/src/main/java/com/squirtles/feature/map/NaverMap.kt
+++ b/feature/map/src/main/java/com/squirtles/feature/map/NaverMap.kt
@@ -1,6 +1,6 @@
 package com.squirtles.feature.map
 
-import android.Manifest
+import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.Context
 import android.graphics.PointF
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -20,7 +19,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.viewinterop.AndroidView
-import androidx.core.content.PermissionChecker
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
@@ -39,45 +37,61 @@ import com.naver.maps.map.UiSettings
 import com.naver.maps.map.clustering.Clusterer
 import com.naver.maps.map.overlay.CircleOverlay
 import com.naver.maps.map.overlay.LocationOverlay
+import com.naver.maps.map.overlay.Marker
 import com.naver.maps.map.overlay.OverlayImage
 import com.naver.maps.map.util.FusedLocationSource
+import com.squirtles.core.common.ui.MusicRoadPermissions.checkLocationPermission
 import com.squirtles.core.common.ui.theme.Primary
 import com.squirtles.core.common.ui.theme.Purple15
+import com.squirtles.core.model.LocationPoint
 import com.squirtles.feature.map.marker.MarkerKey
 import com.squirtles.feature.map.marker.buildClusterer
 import kotlinx.coroutines.launch
-import kotlin.coroutines.resume
-import kotlin.coroutines.suspendCoroutine
 
 @Composable
 fun NaverMap(
     mapViewModel: MapViewModel,
-    lastLocation: Location?
+    lastLocation: LocationPoint?
 ) {
     val context = LocalContext.current
-    val mapView = remember { MapView(context) }
-    val naverMap = remember { mutableStateOf<NaverMap?>(null) }
-
-    val fusedLocationClient = remember { LocationServices.getFusedLocationProviderClient(context) }
-    val locationSource =
-        remember { FusedLocationSource(context as Activity, LOCATION_PERMISSION_REQUEST_CODE) }
-    val locationOverlay = remember { mutableStateOf<LocationOverlay?>(null) }
-    val circleOverlay = remember { CircleOverlay() }
-    var clusterer by remember { mutableStateOf<Clusterer<MarkerKey>?>(null) }
-
     val lifecycleOwner = LocalLifecycleOwner.current
     val coroutineScope = rememberCoroutineScope()
 
-    val centerLatLng by mapViewModel.centerLatLng.collectAsStateWithLifecycle()
+    // permission
+    val hasPermission by remember { mutableStateOf(checkLocationPermission(context)) }
 
-    LaunchedEffect(lastLocation) {
-        // 현재 위치와 마지막 위치가 5미터 이상 차이가 날때만 현위치 기준 반경 100m 픽 정보 개수 불러오기
+    // map
+    val mapView = remember { MapView(context) }
+    val naverMap = remember { mutableStateOf<NaverMap?>(null) }
+
+    // overlays
+    val locationOverlay = remember { mutableStateOf<LocationOverlay?>(null) }
+    val circleOverlay = remember { CircleOverlay().apply { initCircleOverlay() } }
+
+    // location sources
+    val fusedLocationClient = remember { LocationServices.getFusedLocationProviderClient(context) }
+    val locationSource = remember { FusedLocationSource(context as Activity, LOCATION_PERMISSION_REQUEST_CODE) }
+    var clusterer by remember { mutableStateOf<Clusterer<MarkerKey>?>(null) }
+
+    // location points
+    val centerPoint by mapViewModel.centerPoint.collectAsStateWithLifecycle()
+
+    // clicked marker
+    val clickedMarkerState by mapViewModel.clickedMarkerState.collectAsStateWithLifecycle()
+
+    LaunchedEffect(naverMap.value, lastLocation) {
+        if (naverMap.value != null && !hasPermission) {
+            lastLocation?.let {
+                naverMap.value?.initCameraPosition(mapViewModel.lastCameraPosition, lastLocation)
+            }
+        }
+
         lastLocation?.let {
-            mapViewModel.requestPickNotificationArea(lastLocation, CIRCLE_RADIUS_METER)
+            mapViewModel.requestPickNotificationArea(it, CIRCLE_RADIUS_METER)
         }
     }
 
-    LaunchedEffect(centerLatLng) {
+    LaunchedEffect(centerPoint) {
         naverMap.value?.projection?.fromScreenLocation(PointF(0F, 0F))?.run {
             mapViewModel.fetchPicksInBounds(
                 leftTop = this,
@@ -91,6 +105,10 @@ fun NaverMap(
 
         onDispose {
             clusterer?.clear()
+
+            naverMap.value?.let {
+                mapViewModel.setLastCameraPosition(it.cameraPosition)
+            }
         }
     }
 
@@ -110,9 +128,6 @@ fun NaverMap(
         lifecycleOwner.lifecycle.addObserver(mapLifecycleObserver)
 
         onDispose {
-            naverMap.value?.let {
-                mapViewModel.setLastCameraPosition(it.cameraPosition)
-            }
             lifecycleOwner.lifecycle.removeObserver(mapLifecycleObserver)
             mapView.onDestroy()
         }
@@ -122,33 +137,28 @@ fun NaverMap(
         factory = {
             mapView.apply {
                 coroutineScope.launch {
-                    naverMap.value = suspendCoroutine { continuation ->
-                        getMapAsync {
-                            continuation.resume(it)
-                        }
-                    }
-
-                    naverMap.value?.run {
-                        mapType = NaverMap.MapType.Navi
-                        initMapSettings()
-                        initDeviceLocation(
-                            context = context,
-                            circleOverlay = circleOverlay,
-                            fusedLocationClient = fusedLocationClient,
-                            lastCameraPosition = mapViewModel.lastCameraPosition
-                        ) {
-                            mapViewModel.fetchPicksInBounds(
-                                leftTop = this.projection.fromScreenLocation(PointF(0F, 0F)),
-                                clusterer = clusterer
+                    mapView.getMapAsync { map ->
+                        naverMap.value = map
+                        map.run {
+                            initMapSettings()
+                            initLocationSource(hasPermission, locationSource)
+                            initDeviceLocation(
+                                hasPermission = hasPermission,
+                                circleOverlay = circleOverlay,
+                                fusedLocationClient = fusedLocationClient,
+                                lastCameraPosition = mapViewModel.lastCameraPosition
                             )
+                            initLocationOverlay(hasPermission) { overlay ->
+                                locationOverlay.value = overlay
+                            }
+                            moveCamera(CameraUpdate.zoomTo(INITIAL_CAMERA_ZOOM))
+                            setLocationChangeListener(circleOverlay, mapViewModel)
+                            setMapClickListener { mapViewModel.resetClickedMarkerState(context) }
+                            setCameraIdleListener { centerLatLng ->
+                                mapViewModel.updateCenterLatLng(centerLatLng.latitude, centerLatLng.longitude)
+                            }
+                            clusterer?.map = this
                         }
-                        initLocationOverlay(locationSource, locationOverlay)
-                        setLocationChangeListener(circleOverlay, mapViewModel)
-                        setMapClickListener { mapViewModel.resetClickedMarkerState(context) }
-                        setCameraIdleListener { centerLatLng ->
-                            mapViewModel.updateCenterLatLng(centerLatLng)
-                        }
-                        clusterer?.map = this
                     }
                 }
             }
@@ -161,49 +171,64 @@ fun NaverMap(
     }
 }
 
-internal fun setCameraToMarker(
-    map: NaverMap,
+internal fun NaverMap.setCameraToMarker(
     clickedMarkerPosition: LatLng
 ) {
     val cameraUpdate = CameraUpdate
         .scrollTo(clickedMarkerPosition)
         .animate(CameraAnimation.Easing)
-    map.moveCamera(cameraUpdate)
+    moveCamera(cameraUpdate)
 }
 
-private fun NaverMap.initLocationOverlay(
+private fun NaverMap.initLocationSource(
+    hasPermission: Boolean,
     currentLocationSource: FusedLocationSource,
-    currentLocationOverlay: MutableState<LocationOverlay?>
 ) {
-    locationSource = currentLocationSource
-    locationTrackingMode = LocationTrackingMode.Follow
-    currentLocationOverlay.value = locationOverlay
-    currentLocationOverlay.value?.run {
-        isVisible = true
-        icon = OverlayImage.fromResource(R.drawable.ic_location)
+    if (hasPermission) {
+        locationSource = currentLocationSource
+        locationTrackingMode = LocationTrackingMode.Follow
     }
 }
 
+private fun NaverMap.initLocationOverlay(
+    hasPermission: Boolean,
+    setLocationOverlayState: (LocationOverlay) -> (Unit),
+) {
+    if (hasPermission) {
+        setLocationOverlayState(locationOverlay.apply {
+            isVisible = true
+            icon = OverlayImage.fromResource(R.drawable.ic_location)
+        })
+    }
+}
+
+@SuppressLint("MissingPermission")
 private fun NaverMap.initDeviceLocation(
-    context: Context,
+    hasPermission: Boolean,
     circleOverlay: CircleOverlay,
     fusedLocationClient: FusedLocationProviderClient,
     lastCameraPosition: CameraPosition?,
-    fetchPicksInBounds: () -> Unit,
 ) {
-    if (checkSelfPermission(context)) {
+    if (hasPermission) {
         fusedLocationClient.lastLocation.addOnSuccessListener { location ->
             if (location != null) {
                 locationOverlay.position = LatLng(location)
-                setCircleOverlay(circleOverlay, location)
-                lastCameraPosition?.let {
-                    moveCamera(CameraUpdate.toCameraPosition(it))
-                    fetchPicksInBounds()
-                } ?: run {
-                    moveCamera(CameraUpdate.scrollTo(LatLng(location)))
-                    moveCamera(CameraUpdate.zoomTo(INITIAL_CAMERA_ZOOM))
-                }
+                setCircleOverlayLocation(circleOverlay, location)
+                initCameraPosition(lastCameraPosition, LocationPoint(location.latitude, location.longitude))
             }
+        }
+    }
+}
+
+private fun NaverMap.initCameraPosition(
+    lastCameraPosition: CameraPosition?,
+    lastLocation: LocationPoint?
+) {
+    lastCameraPosition?.let {
+        moveCamera(CameraUpdate.toCameraPosition(it))
+    } ?: run {
+        lastLocation?.let {
+            moveCamera(CameraUpdate.scrollTo(LatLng(it.latitude, it.longitude)))
         }
     }
 }
@@ -213,27 +238,31 @@ private fun NaverMap.setLocationChangeListener(
     mapViewModel: MapViewModel
 ) {
     addOnLocationChangeListener { location ->
-        this.setCircleOverlay(circleOverlay, location)
-        mapViewModel.updateCurLocation(location)
+        setCircleOverlayLocation(circleOverlay, location)
+        mapViewModel.updateCurLocation(location.latitude, location.longitude)
     }
 }
 
-private fun NaverMap.setCircleOverlay(circleOverlay: CircleOverlay, location: Location) {
+private fun CircleOverlay.initCircleOverlay() {
+    color = Purple15.toArgb()
+    outlineColor = Primary.toArgb()
+    outlineWidth = 3
+    radius = CIRCLE_RADIUS_METER
+}
+
+private fun NaverMap.setCircleOverlayLocation(circleOverlay: CircleOverlay, location: Location) {
     circleOverlay.center = LatLng(location.latitude, location.longitude)
-    circleOverlay.color = Purple15.toArgb()
-    circleOverlay.outlineColor = Primary.toArgb()
-    circleOverlay.outlineWidth = 3
-    circleOverlay.radius = CIRCLE_RADIUS_METER
-    circleOverlay.map = this
+    if (circleOverlay.map == null) circleOverlay.map = this
 }
 
 private fun NaverMap.initMapSettings() {
-    extent = LatLngBounds(SOUTHWEST, NORTHEAST)
+    mapType = MAP_TYPE
+    extent = LatLngBounds(SOUTHWEST_LIMIT, NORTHEAST_LIMIT)
     setCameraZoomLimit()
-    uiSettings.setNaverMapMapUi()
+    uiSettings.setNaverMapUi()
 }
 
-private fun UiSettings.setNaverMapMapUi() {
+private fun UiSettings.setNaverMapUi() {
     isLocationButtonEnabled = true
     isZoomControlEnabled = false
     isTiltGesturesEnabled = false
@@ -262,23 +291,13 @@ private fun NaverMap.setCameraIdleListener(
     }
 }
 
-private fun checkSelfPermission(context: Context): Boolean {
-    return PermissionChecker.checkSelfPermission(context, PERMISSIONS[0]) ==
-            PermissionChecker.PERMISSION_GRANTED &&
-            PermissionChecker.checkSelfPermission(context, PERMISSIONS[1]) ==
-            PermissionChecker.PERMISSION_GRANTED
-}
-
-private val SOUTHWEST = LatLng(33.011268, 124.344361)
-private val NORTHEAST = LatLng(39.346507, 130.826372)
+private val MAP_TYPE = NaverMap.MapType.Navi
+private val SOUTHWEST_LIMIT = LatLng(33.011268, 124.344361)
+private val NORTHEAST_LIMIT = LatLng(39.346507, 130.826372)
 private const val LOCATION_PERMISSION_REQUEST_CODE = 1000
 private const val CIRCLE_RADIUS_METER = 100.0
 private const val INITIAL_CAMERA_ZOOM = 16.5
 private const val MIN_ZOOM_LEVEL = 6.0
 private const val MAX_ZOOM_LEVEL = 18.0
-private val PERMISSIONS = arrayOf(
-    Manifest.permission.ACCESS_FINE_LOCATION,
-    Manifest.permission.ACCESS_COARSE_LOCATION
-)
 internal const val DEFAULT_MARKER_Z_INDEX = 0
 internal const val CLICKED_MARKER_Z_INDEX = 100

--- a/feature/map/src/main/java/com/squirtles/feature/map/NaverMap.kt
+++ b/feature/map/src/main/java/com/squirtles/feature/map/NaverMap.kt
@@ -48,15 +48,13 @@ import kotlinx.coroutines.launch
 
 @Composable
 fun NaverMap(
+    hasPermission: Boolean,
     mapViewModel: MapViewModel,
     lastLocation: LocationPoint?
 ) {
     val context = LocalContext.current
     val lifecycleOwner = LocalLifecycleOwner.current
     val coroutineScope = rememberCoroutineScope()
-
-    // permission
-    val hasPermission by remember { mutableStateOf(checkLocationPermission(context)) }
 
     // map
     val mapView = remember { MapView(context) }
@@ -73,7 +71,7 @@ fun NaverMap(
 
     // location points
     val centerPoint by mapViewModel.centerPoint.collectAsStateWithLifecycle()
-    
+
     LaunchedEffect(naverMap.value, lastLocation) {
         if (naverMap.value != null && !hasPermission) {
             lastLocation?.let {

--- a/feature/map/src/main/java/com/squirtles/feature/map/NaverMap.kt
+++ b/feature/map/src/main/java/com/squirtles/feature/map/NaverMap.kt
@@ -74,9 +74,7 @@ fun NaverMap(
 
     LaunchedEffect(naverMap.value, lastLocation) {
         if (naverMap.value != null && !hasPermission) {
-            lastLocation?.let {
-                naverMap.value?.initCameraPosition(mapViewModel.lastCameraPosition, lastLocation)
-            }
+            naverMap.value?.initCameraPosition(mapViewModel.lastCameraPosition, lastLocation)
         }
 
         if (hasPermission) {

--- a/feature/map/src/main/java/com/squirtles/feature/map/NaverMap.kt
+++ b/feature/map/src/main/java/com/squirtles/feature/map/NaverMap.kt
@@ -2,7 +2,6 @@ package com.squirtles.feature.map
 
 import android.annotation.SuppressLint
 import android.app.Activity
-import android.content.Context
 import android.graphics.PointF
 import android.location.Location
 import androidx.compose.foundation.isSystemInDarkTheme
@@ -22,6 +21,7 @@ import androidx.compose.ui.viewinterop.AndroidView
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationServices
 import com.naver.maps.geometry.LatLng
@@ -38,45 +38,25 @@ import com.naver.maps.map.overlay.CircleOverlay
 import com.naver.maps.map.overlay.LocationOverlay
 import com.naver.maps.map.overlay.OverlayImage
 import com.naver.maps.map.util.FusedLocationSource
+import com.squirtles.core.common.ui.MusicRoadPermissions.checkLocationPermission
 import com.squirtles.core.common.ui.theme.Primary
 import com.squirtles.core.common.ui.theme.Purple15
 import com.squirtles.core.model.LocationPoint
 import com.squirtles.feature.map.marker.MarkerKey
+import com.squirtles.feature.map.marker.buildClusterer
 import kotlinx.coroutines.launch
 
-internal data class NaverMapActions(
-    val fetchPicksInBounds: (LatLng, Clusterer<MarkerKey>?) -> Unit,
-    val resetClickedMarkerState: (Context) -> Unit,
-    val requestPickNotificationArea: (Double, Double, Double) -> Unit,
-    val updateCurLocation: (Double, Double) -> Unit,
-    val updateCenterLocation: (Double, Double) -> Unit,
-    val setLastCameraPosition: (CameraPosition) -> Unit,
-    val getLastCameraPosition: () -> CameraPosition?
-) {
-    companion object {
-        val preview = NaverMapActions(
-            requestPickNotificationArea = { _, _, _ -> },
-            fetchPicksInBounds = { _, _ -> },
-            setLastCameraPosition = { },
-            resetClickedMarkerState = { },
-            updateCenterLocation = { _, _ -> },
-            updateCurLocation = { _, _ -> },
-            getLastCameraPosition = { null }
-        )
-    }
-}
-
 @Composable
-internal fun NaverMap(
-    naverMapActions: NaverMapActions,
-    centerPoint: LocationPoint?,
-    lastLocation: LocationPoint?,
-    hasPermission: () -> Boolean,
-    getClusterer: () -> Clusterer<MarkerKey>?
+fun NaverMap(
+    mapViewModel: MapViewModel,
+    lastLocation: LocationPoint?
 ) {
     val context = LocalContext.current
     val lifecycleOwner = LocalLifecycleOwner.current
     val coroutineScope = rememberCoroutineScope()
+
+    // permission
+    val hasPermission by remember { mutableStateOf(checkLocationPermission(context)) }
 
     // map
     val mapView = remember { MapView(context) }
@@ -91,32 +71,41 @@ internal fun NaverMap(
     val locationSource = remember { FusedLocationSource(context as Activity, LOCATION_PERMISSION_REQUEST_CODE) }
     var clusterer by remember { mutableStateOf<Clusterer<MarkerKey>?>(null) }
 
+    // location points
+    val centerPoint by mapViewModel.centerPoint.collectAsStateWithLifecycle()
+
+    // clicked marker
+    val clickedMarkerState by mapViewModel.clickedMarkerState.collectAsStateWithLifecycle()
+
     LaunchedEffect(naverMap.value, lastLocation) {
-        if (naverMap.value != null && !hasPermission()) {
+        if (naverMap.value != null && !hasPermission) {
             lastLocation?.let {
-                naverMap.value?.initCameraPosition(naverMapActions.getLastCameraPosition(), lastLocation)
+                naverMap.value?.initCameraPosition(mapViewModel.lastCameraPosition, lastLocation)
             }
         }
 
         lastLocation?.let {
-            naverMapActions.requestPickNotificationArea(it.latitude, it.longitude, CIRCLE_RADIUS_METER)
+            mapViewModel.requestPickNotificationArea(it.latitude, it.longitude, CIRCLE_RADIUS_METER)
         }
     }
 
     LaunchedEffect(centerPoint) {
         naverMap.value?.projection?.fromScreenLocation(PointF(0F, 0F))?.run {
-            naverMapActions.fetchPicksInBounds(this, clusterer)
+            mapViewModel.fetchPicksInBounds(
+                leftTop = this,
+                clusterer = clusterer
+            )
         }
     }
 
     DisposableEffect(Unit) {
-        clusterer = getClusterer()
+        clusterer = buildClusterer(context, mapViewModel)
 
         onDispose {
             clusterer?.clear()
 
             naverMap.value?.let {
-                naverMapActions.setLastCameraPosition(it.cameraPosition)
+                mapViewModel.setLastCameraPosition(it.cameraPosition)
             }
         }
     }
@@ -150,21 +139,21 @@ internal fun NaverMap(
                         naverMap.value = map
                         map.run {
                             initMapSettings()
-                            initLocationSource(hasPermission(), locationSource)
+                            initLocationSource(hasPermission, locationSource)
                             initDeviceLocation(
-                                hasPermission = hasPermission(),
+                                hasPermission = hasPermission,
                                 circleOverlay = circleOverlay,
                                 fusedLocationClient = fusedLocationClient,
-                                lastCameraPosition = naverMapActions.getLastCameraPosition()
+                                lastCameraPosition = mapViewModel.lastCameraPosition
                             )
-                            initLocationOverlay(hasPermission()) { overlay ->
+                            initLocationOverlay(hasPermission) { overlay ->
                                 locationOverlay.value = overlay
                             }
                             moveCamera(CameraUpdate.zoomTo(INITIAL_CAMERA_ZOOM))
-                            setLocationChangeListener(circleOverlay, naverMapActions.updateCurLocation)
-                            setMapClickListener { naverMapActions.resetClickedMarkerState(context) }
+                            setLocationChangeListener(circleOverlay, mapViewModel)
+                            setMapClickListener { mapViewModel.resetClickedMarkerState(context) }
                             setCameraIdleListener { centerLatLng ->
-                                naverMapActions.updateCenterLocation(centerLatLng.latitude, centerLatLng.longitude)
+                                mapViewModel.updateCenterLocation(centerLatLng.latitude, centerLatLng.longitude)
                             }
                             clusterer?.map = this
                         }
@@ -244,11 +233,11 @@ private fun NaverMap.initCameraPosition(
 
 private fun NaverMap.setLocationChangeListener(
     circleOverlay: CircleOverlay,
-    updateCurLocation: (Double, Double) -> Unit,
+    mapViewModel: MapViewModel
 ) {
     addOnLocationChangeListener { location ->
         setCircleOverlayLocation(circleOverlay, location)
-        updateCurLocation(location.latitude, location.longitude)
+        mapViewModel.updateCurLocation(location.latitude, location.longitude)
     }
 }
 

--- a/feature/map/src/main/java/com/squirtles/feature/map/NaverMap.kt
+++ b/feature/map/src/main/java/com/squirtles/feature/map/NaverMap.kt
@@ -38,7 +38,6 @@ import com.naver.maps.map.overlay.CircleOverlay
 import com.naver.maps.map.overlay.LocationOverlay
 import com.naver.maps.map.overlay.OverlayImage
 import com.naver.maps.map.util.FusedLocationSource
-import com.squirtles.core.common.ui.MusicRoadPermissions.checkLocationPermission
 import com.squirtles.core.common.ui.theme.Primary
 import com.squirtles.core.common.ui.theme.Purple15
 import com.squirtles.core.model.LocationPoint

--- a/feature/map/src/main/java/com/squirtles/feature/map/NaverMap.kt
+++ b/feature/map/src/main/java/com/squirtles/feature/map/NaverMap.kt
@@ -73,10 +73,7 @@ fun NaverMap(
 
     // location points
     val centerPoint by mapViewModel.centerPoint.collectAsStateWithLifecycle()
-
-    // clicked marker
-    val clickedMarkerState by mapViewModel.clickedMarkerState.collectAsStateWithLifecycle()
-
+    
     LaunchedEffect(naverMap.value, lastLocation) {
         if (naverMap.value != null && !hasPermission) {
             lastLocation?.let {
@@ -84,8 +81,10 @@ fun NaverMap(
             }
         }
 
-        lastLocation?.let {
-            mapViewModel.requestPickNotificationArea(it.latitude, it.longitude, CIRCLE_RADIUS_METER)
+        if (hasPermission) {
+            lastLocation?.let {
+                mapViewModel.requestPickNotificationArea(it.latitude, it.longitude, CIRCLE_RADIUS_METER)
+            }
         }
     }
 

--- a/feature/map/src/main/java/com/squirtles/feature/map/NaverMap.kt
+++ b/feature/map/src/main/java/com/squirtles/feature/map/NaverMap.kt
@@ -22,7 +22,6 @@ import androidx.compose.ui.viewinterop.AndroidView
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationServices
 import com.naver.maps.geometry.LatLng
@@ -37,7 +36,6 @@ import com.naver.maps.map.UiSettings
 import com.naver.maps.map.clustering.Clusterer
 import com.naver.maps.map.overlay.CircleOverlay
 import com.naver.maps.map.overlay.LocationOverlay
-import com.naver.maps.map.overlay.Marker
 import com.naver.maps.map.overlay.OverlayImage
 import com.naver.maps.map.util.FusedLocationSource
 import com.squirtles.core.common.ui.MusicRoadPermissions.checkLocationPermission
@@ -45,20 +43,41 @@ import com.squirtles.core.common.ui.theme.Primary
 import com.squirtles.core.common.ui.theme.Purple15
 import com.squirtles.core.model.LocationPoint
 import com.squirtles.feature.map.marker.MarkerKey
-import com.squirtles.feature.map.marker.buildClusterer
 import kotlinx.coroutines.launch
 
+internal data class NaverMapActions(
+    val fetchPicksInBounds: (LatLng, Clusterer<MarkerKey>?) -> Unit,
+    val resetClickedMarkerState: (Context) -> Unit,
+    val requestPickNotificationArea: (Double, Double, Double) -> Unit,
+    val updateCurLocation: (Double, Double) -> Unit,
+    val updateCenterLocation: (Double, Double) -> Unit,
+    val setLastCameraPosition: (CameraPosition) -> Unit,
+    val getLastCameraPosition: () -> CameraPosition?
+) {
+    companion object {
+        val preview = NaverMapActions(
+            requestPickNotificationArea = { _, _, _ -> },
+            fetchPicksInBounds = { _, _ -> },
+            setLastCameraPosition = { },
+            resetClickedMarkerState = { },
+            updateCenterLocation = { _, _ -> },
+            updateCurLocation = { _, _ -> },
+            getLastCameraPosition = { null }
+        )
+    }
+}
+
 @Composable
-fun NaverMap(
-    mapViewModel: MapViewModel,
-    lastLocation: LocationPoint?
+internal fun NaverMap(
+    naverMapActions: NaverMapActions,
+    centerPoint: LocationPoint?,
+    lastLocation: LocationPoint?,
+    hasPermission: () -> Boolean,
+    getClusterer: () -> Clusterer<MarkerKey>?
 ) {
     val context = LocalContext.current
     val lifecycleOwner = LocalLifecycleOwner.current
     val coroutineScope = rememberCoroutineScope()
-
-    // permission
-    val hasPermission by remember { mutableStateOf(checkLocationPermission(context)) }
 
     // map
     val mapView = remember { MapView(context) }
@@ -73,41 +92,32 @@ fun NaverMap(
     val locationSource = remember { FusedLocationSource(context as Activity, LOCATION_PERMISSION_REQUEST_CODE) }
     var clusterer by remember { mutableStateOf<Clusterer<MarkerKey>?>(null) }
 
-    // location points
-    val centerPoint by mapViewModel.centerPoint.collectAsStateWithLifecycle()
-
-    // clicked marker
-    val clickedMarkerState by mapViewModel.clickedMarkerState.collectAsStateWithLifecycle()
-
     LaunchedEffect(naverMap.value, lastLocation) {
-        if (naverMap.value != null && !hasPermission) {
+        if (naverMap.value != null && !hasPermission()) {
             lastLocation?.let {
-                naverMap.value?.initCameraPosition(mapViewModel.lastCameraPosition, lastLocation)
+                naverMap.value?.initCameraPosition(naverMapActions.getLastCameraPosition(), lastLocation)
             }
         }
 
         lastLocation?.let {
-            mapViewModel.requestPickNotificationArea(it, CIRCLE_RADIUS_METER)
+            naverMapActions.requestPickNotificationArea(it.latitude, it.longitude, CIRCLE_RADIUS_METER)
         }
     }
 
     LaunchedEffect(centerPoint) {
         naverMap.value?.projection?.fromScreenLocation(PointF(0F, 0F))?.run {
-            mapViewModel.fetchPicksInBounds(
-                leftTop = this,
-                clusterer = clusterer
-            )
+            naverMapActions.fetchPicksInBounds(this, clusterer)
         }
     }
 
     DisposableEffect(Unit) {
-        clusterer = buildClusterer(context, mapViewModel)
+        clusterer = getClusterer()
 
         onDispose {
             clusterer?.clear()
 
             naverMap.value?.let {
-                mapViewModel.setLastCameraPosition(it.cameraPosition)
+                naverMapActions.setLastCameraPosition(it.cameraPosition)
             }
         }
     }
@@ -141,21 +151,21 @@ fun NaverMap(
                         naverMap.value = map
                         map.run {
                             initMapSettings()
-                            initLocationSource(hasPermission, locationSource)
+                            initLocationSource(hasPermission(), locationSource)
                             initDeviceLocation(
-                                hasPermission = hasPermission,
+                                hasPermission = hasPermission(),
                                 circleOverlay = circleOverlay,
                                 fusedLocationClient = fusedLocationClient,
-                                lastCameraPosition = mapViewModel.lastCameraPosition
+                                lastCameraPosition = naverMapActions.getLastCameraPosition()
                             )
-                            initLocationOverlay(hasPermission) { overlay ->
+                            initLocationOverlay(hasPermission()) { overlay ->
                                 locationOverlay.value = overlay
                             }
                             moveCamera(CameraUpdate.zoomTo(INITIAL_CAMERA_ZOOM))
-                            setLocationChangeListener(circleOverlay, mapViewModel)
-                            setMapClickListener { mapViewModel.resetClickedMarkerState(context) }
+                            setLocationChangeListener(circleOverlay, naverMapActions.updateCurLocation)
+                            setMapClickListener { naverMapActions.resetClickedMarkerState(context) }
                             setCameraIdleListener { centerLatLng ->
-                                mapViewModel.updateCenterLatLng(centerLatLng.latitude, centerLatLng.longitude)
+                                naverMapActions.updateCenterLocation(centerLatLng.latitude, centerLatLng.longitude)
                             }
                             clusterer?.map = this
                         }
@@ -235,11 +245,11 @@ private fun NaverMap.initCameraPosition(
 
 private fun NaverMap.setLocationChangeListener(
     circleOverlay: CircleOverlay,
-    mapViewModel: MapViewModel
+    updateCurLocation: (Double, Double) -> Unit,
 ) {
     addOnLocationChangeListener { location ->
         setCircleOverlayLocation(circleOverlay, location)
-        mapViewModel.updateCurLocation(location.latitude, location.longitude)
+        updateCurLocation(location.latitude, location.longitude)
     }
 }
 

--- a/feature/map/src/main/java/com/squirtles/feature/map/components/MapBottomNavBar.kt
+++ b/feature/map/src/main/java/com/squirtles/feature/map/components/MapBottomNavBar.kt
@@ -1,7 +1,6 @@
 package com.squirtles.feature.map.components
 
 import android.content.res.Configuration
-import android.location.Location
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
@@ -25,15 +24,15 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.squirtles.core.common.ui.theme.MusicRoadTheme
 import com.squirtles.core.common.ui.theme.Primary
-import com.squirtles.feature.map.BottomNavigationSize
 import com.squirtles.feature.map.BottomNavigationIconSize
+import com.squirtles.feature.map.BottomNavigationSize
 import com.squirtles.feature.map.R
 import com.squirtles.feature.map.navigation.NavTab
 
 @Composable
 internal fun MapBottomNavBar(
     modifier: Modifier = Modifier,
-    lastLocation: Location?,
+    isActivated: Boolean,
     onFavoriteClick: () -> Unit,
     onCenterClick: () -> Unit,
     onUserInfoClick: () -> Unit,
@@ -79,29 +78,34 @@ internal fun MapBottomNavBar(
                 .size(BottomNavigationIconSize.CENTER.size.dp)
                 .clip(CircleShape)
                 .background(
-                    color = lastLocation?.let {
+                    color = if (isActivated)
                         MaterialTheme.colorScheme.primary
-                    } ?: Color.Gray
+                    else
+                        Color.Gray
                 ),
             tab = NavTab.SEARCH,
             painter = painterResource(R.drawable.ic_musical_note_64),
             tint = MaterialTheme.colorScheme.onPrimary,
-            onClick = onCenterClick
+            onClick = onCenterClick,
+            isActivated = isActivated,
         )
     }
 }
 
 @Composable
 private fun MapBottomNavigationItem(
-    modifier: Modifier = Modifier,
     tab: NavTab,
     painter: Painter?,
     tint: Color,
-    onClick: () -> Unit
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    isActivated: Boolean = true
 ) {
     Box(
         modifier = modifier
-            .clickable { onClick() },
+            .clickable {
+                if (isActivated) onClick()
+            },
         contentAlignment = Alignment.Center,
     ) {
         Icon(
@@ -119,7 +123,7 @@ fun BottomNavigationLightPreview() {
     MusicRoadTheme {
         MapBottomNavBar(
             onFavoriteClick = {},
-            lastLocation = null,
+            isActivated = false,
             onCenterClick = {},
             onUserInfoClick = {}
         )
@@ -132,7 +136,7 @@ fun BottomNavigationDarkPreview() {
     MusicRoadTheme {
         MapBottomNavBar(
             onFavoriteClick = {},
-            lastLocation = null,
+            isActivated = true,
             onCenterClick = {},
             onUserInfoClick = {}
         )

--- a/feature/map/src/main/java/com/squirtles/feature/map/components/PickNotificationBanner.kt
+++ b/feature/map/src/main/java/com/squirtles/feature/map/components/PickNotificationBanner.kt
@@ -80,26 +80,27 @@ fun PickNotificationBanner(
 private fun PickNotificationBannerPreview() {
     MusicRoadTheme {
         PickNotificationBanner(
-            nearPicks = listOf( Pick(
-                id = "",
-                song = Song(
+            nearPicks = listOf(
+                Pick(
                     id = "",
-                    songName = "",
-                    artistName = "",
-                    albumName = "",
-                    imageUrl = "",
-                    genreNames = listOf(),
-                    bgColor = "#000000".toColorInt(),
-                    externalUrl = "",
-                    previewUrl = ""
-                ),
-                comment = "",
-                createdAt = "",
-                createdBy = Creator(uid = "", userName = "짱구"),
-                favoriteCount = 0,
-                location = LocationPoint(1.0, 1.0),
-                musicVideoUrl = "",
-            )
+                    song = Song(
+                        id = "",
+                        songName = "",
+                        artistName = "",
+                        albumName = "",
+                        imageUrl = "",
+                        genreNames = listOf(),
+                        bgColor = "#000000".toColorInt(),
+                        externalUrl = "",
+                        previewUrl = ""
+                    ),
+                    comment = "",
+                    createdAt = "",
+                    createdBy = Creator(uid = "", userName = "짱구"),
+                    favoriteCount = 0,
+                    location = LocationPoint(1.0, 1.0),
+                    musicVideoUrl = "",
+                )
             ),
             onClick = { }
         )

--- a/feature/map/src/main/java/com/squirtles/feature/map/marker/Clusterer.kt
+++ b/feature/map/src/main/java/com/squirtles/feature/map/marker/Clusterer.kt
@@ -99,7 +99,7 @@ internal fun <T : ClusteringKey> buildClusterer(
                     true
                 }
 
-                if (mapViewModel.clickedMarkerState.value.prevClickedMarker?.position == marker.position) {
+                if (mapViewModel.clickedMarkerState.value.lastClickedMarker?.position == marker.position) {
                     mapViewModel.clickedMarkerState.value.clusterPickList?.let {
                         mapViewModel.updateClickedMarkerState(
                             context = context,
@@ -150,7 +150,7 @@ internal fun <T : ClusteringKey> buildClusterer(
                     }
 
                     // 2개짜리 클러스터 마커가 클릭된 상태에서 항목 삭제 시 바텀 시트 -> 인포윈도우
-                    if (mapViewModel.clickedMarkerState.value.prevClickedMarker?.position == marker.position) {
+                    if (mapViewModel.clickedMarkerState.value.lastClickedMarker?.position == marker.position) {
                         mapViewModel.updateClickedMarkerState(
                             context = context,
                             marker = marker,

--- a/feature/map/src/main/java/com/squirtles/feature/map/marker/Clusterer.kt
+++ b/feature/map/src/main/java/com/squirtles/feature/map/marker/Clusterer.kt
@@ -89,14 +89,14 @@ internal fun <T : ClusteringKey> buildClusterer(
                     marker.handleMarkerClick(
                         context = context,
                         clusterTag = info.tag.toString(),
-                        setClickedMarkerState = mapViewModel::setClickedMarkerState,
+                        setClickedMarkerState = mapViewModel::updateClickedMarkerState,
                     )
                     true
                 }
 
                 if (mapViewModel.clickedMarkerState.value.prevClickedMarker?.position == marker.position) {
                     mapViewModel.clickedMarkerState.value.clusterPickList?.let {
-                        mapViewModel.setClickedMarkerState(
+                        mapViewModel.updateClickedMarkerState(
                             context = context,
                             marker = marker,
                             clusterTag = info.tag.toString()
@@ -134,14 +134,14 @@ internal fun <T : ClusteringKey> buildClusterer(
                         marker.handleMarkerClick(
                             context = context,
                             pickId = pick.id,
-                            setClickedMarkerState = mapViewModel::setClickedMarkerState
+                            setClickedMarkerState = mapViewModel::updateClickedMarkerState
                         )
                         true
                     }
 
                     // 2개짜리 클러스터 마커가 클릭된 상태에서 항목 삭제 시 바텀 시트 -> 인포윈도우
                     if (mapViewModel.clickedMarkerState.value.prevClickedMarker?.position == marker.position) {
-                        mapViewModel.setClickedMarkerState(
+                        mapViewModel.updateClickedMarkerState(
                             context = context,
                             marker = marker,
                             pickId = pick.id

--- a/feature/map/src/main/java/com/squirtles/feature/map/marker/Clusterer.kt
+++ b/feature/map/src/main/java/com/squirtles/feature/map/marker/Clusterer.kt
@@ -86,11 +86,16 @@ internal fun <T : ClusteringKey> buildClusterer(
                 marker.captionText = info.size.toString()
                 marker.captionColor = captionColor.toArgb()
                 marker.onClickListener = Overlay.OnClickListener {
-                    marker.handleMarkerClick(
-                        context = context,
-                        clusterTag = info.tag.toString(),
-                        setClickedMarkerState = mapViewModel::updateClickedMarkerState,
-                    )
+                    marker.map?.let { map ->
+                        map.setCameraToMarker(
+                            clickedMarkerPosition = marker.position
+                        )
+                        mapViewModel.updateClickedMarkerState(
+                            context = context,
+                            marker = marker,
+                            clusterTag = info.tag.toString()
+                        )
+                    }
                     true
                 }
 
@@ -131,11 +136,16 @@ internal fun <T : ClusteringKey> buildClusterer(
                 ) {
                     marker.icon = OverlayImage.fromView(leafMarkerIconView)
                     marker.setOnClickListener {
-                        marker.handleMarkerClick(
-                            context = context,
-                            pickId = pick.id,
-                            setClickedMarkerState = mapViewModel::updateClickedMarkerState
-                        )
+                        marker.map?.let { map ->
+                            map.setCameraToMarker(
+                                clickedMarkerPosition = marker.position
+                            )
+                            mapViewModel.updateClickedMarkerState(
+                                context = context,
+                                marker = marker,
+                                pickId = pick.id
+                            )
+                        }
                         true
                     }
 
@@ -156,16 +166,4 @@ internal fun <T : ClusteringKey> buildClusterer(
             }
         })
         .build()
-}
-
-fun Marker.handleMarkerClick(
-    context: Context,
-    clusterTag: String? = null,
-    pickId: String? = null,
-    setClickedMarkerState: (context: Context, marker: Marker, clusterTag: String?, pickId: String?) -> Unit,
-) {
-    map?.let { map ->
-        map.setCameraToMarker(clickedMarkerPosition = position)
-        setClickedMarkerState(context, this, clusterTag, pickId)
-    }
 }

--- a/feature/map/src/main/java/com/squirtles/feature/map/marker/Clusterer.kt
+++ b/feature/map/src/main/java/com/squirtles/feature/map/marker/Clusterer.kt
@@ -1,6 +1,7 @@
 package com.squirtles.feature.map.marker
 
 import android.content.Context
+import android.graphics.Color
 import android.graphics.PointF
 import android.view.View
 import androidx.compose.ui.graphics.toArgb
@@ -55,7 +56,7 @@ internal fun <T : ClusteringKey> buildClusterer(
                 with(marker) {
                     icon = OverlayImage.fromView(View(context))
                     setCaptionAligns(Align.Center)
-                    captionHaloColor = android.graphics.Color.TRANSPARENT
+                    captionHaloColor = Color.TRANSPARENT
                 }
                 return marker
             }
@@ -78,23 +79,18 @@ internal fun <T : ClusteringKey> buildClusterer(
                     else -> White
                 }
                 val clusterMarkerIconView = ClusterMarkerIconView(context, densityType)
+
                 marker.icon = OverlayImage.fromView(clusterMarkerIconView)
                 marker.zIndex = DEFAULT_MARKER_Z_INDEX
                 marker.anchor = PointF(0.5F, 0.5F)
                 marker.captionText = info.size.toString()
                 marker.captionColor = captionColor.toArgb()
                 marker.onClickListener = Overlay.OnClickListener {
-                    marker.map?.let { map ->
-                        setCameraToMarker(
-                            map = map,
-                            clickedMarkerPosition = marker.position
-                        )
-                        mapViewModel.setClickedMarkerState(
-                            context = context,
-                            marker = marker,
-                            clusterTag = info.tag.toString()
-                        )
-                    }
+                    marker.handleMarkerClick(
+                        context = context,
+                        clusterTag = info.tag.toString(),
+                        setClickedMarkerState = mapViewModel::setClickedMarkerState,
+                    )
                     true
                 }
 
@@ -135,17 +131,11 @@ internal fun <T : ClusteringKey> buildClusterer(
                 ) {
                     marker.icon = OverlayImage.fromView(leafMarkerIconView)
                     marker.setOnClickListener {
-                        marker.map?.let { map ->
-                            setCameraToMarker(
-                                map = map,
-                                clickedMarkerPosition = marker.position
-                            )
-                            mapViewModel.setClickedMarkerState(
-                                context = context,
-                                marker = marker,
-                                pickId = pick.id
-                            )
-                        }
+                        marker.handleMarkerClick(
+                            context = context,
+                            pickId = pick.id,
+                            setClickedMarkerState = mapViewModel::setClickedMarkerState
+                        )
                         true
                     }
 
@@ -166,4 +156,16 @@ internal fun <T : ClusteringKey> buildClusterer(
             }
         })
         .build()
+}
+
+fun Marker.handleMarkerClick(
+    context: Context,
+    clusterTag: String? = null,
+    pickId: String? = null,
+    setClickedMarkerState: (context: Context, marker: Marker, clusterTag: String?, pickId: String?) -> Unit,
+) {
+    map?.let { map ->
+        map.setCameraToMarker(clickedMarkerPosition = position)
+        setClickedMarkerState(context, this, clusterTag, pickId)
+    }
 }

--- a/feature/permission/src/main/java/com/squirtles/feature/permission/PermissionData.kt
+++ b/feature/permission/src/main/java/com/squirtles/feature/permission/PermissionData.kt
@@ -1,11 +1,15 @@
 package com.squirtles.feature.permission
 
 import androidx.compose.ui.graphics.vector.ImageVector
+import com.squirtles.core.common.ui.MusicRoadPermissions
 
 internal data class PermissionData(
+    val permission: String,
     val imageVector: ImageVector,
     val contentDescription: String,
     val permissionTitle: String,
     val permissionDescription: String,
-    val isOptional: Boolean = false,
-)
+) {
+    val isOptional: Boolean
+        get() = MusicRoadPermissions.OPTIONAL_PERMISSIONS.contains(permission)
+}

--- a/feature/permission/src/main/java/com/squirtles/feature/permission/PermissionDataFactory.kt
+++ b/feature/permission/src/main/java/com/squirtles/feature/permission/PermissionDataFactory.kt
@@ -1,0 +1,35 @@
+package com.squirtles.feature.permission
+
+import android.Manifest
+import android.content.Context
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Mic
+import androidx.compose.material.icons.filled.MyLocation
+
+internal object PermissionDataFactory {
+    fun from(permission: String, context: Context): PermissionData? {
+        val resources = context.resources
+
+        return when (permission) {
+            Manifest.permission.RECORD_AUDIO -> PermissionData(
+                permission = permission,
+                imageVector = Icons.Default.Mic,
+                contentDescription = resources.getString(R.string.permission_mic_content_desc),
+                permissionTitle = resources.getString(R.string.permission_mic),
+                permissionDescription = resources.getString(R.string.permission_mic_desc)
+            )
+
+            Manifest.permission.ACCESS_FINE_LOCATION -> null
+
+            Manifest.permission.ACCESS_COARSE_LOCATION -> PermissionData(
+                permission = permission,
+                imageVector = Icons.Default.MyLocation,
+                contentDescription = resources.getString(R.string.permission_location_content_desc),
+                permissionTitle = resources.getString(R.string.permission_location),
+                permissionDescription = resources.getString(R.string.permission_location_desc)
+            )
+
+            else -> throw IllegalArgumentException("Unsupported permission: $permission")
+        }
+    }
+}

--- a/feature/permission/src/main/java/com/squirtles/feature/permission/PermissionScreen.kt
+++ b/feature/permission/src/main/java/com/squirtles/feature/permission/PermissionScreen.kt
@@ -152,6 +152,7 @@ fun PermissionScreen(
                             ),
                             PermissionData(
                                 imageVector = Icons.Default.MyLocation,
+                                isOptional = true,
                                 contentDescription = stringResource(R.string.permission_location_content_desc),
                                 permissionTitle = stringResource(R.string.permission_location),
                                 permissionDescription = stringResource(R.string.permission_location_desc),

--- a/feature/permission/src/main/java/com/squirtles/feature/permission/PermissionScreen.kt
+++ b/feature/permission/src/main/java/com/squirtles/feature/permission/PermissionScreen.kt
@@ -20,9 +20,6 @@ import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Mic
-import androidx.compose.material.icons.filled.MyLocation
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -143,21 +140,7 @@ fun PermissionScreen(
                     )
 
                     PermissionMenus(
-                        items = listOf(
-                            PermissionData(
-                                imageVector = Icons.Default.Mic,
-                                contentDescription = stringResource(R.string.permission_mic_content_desc),
-                                permissionTitle = stringResource(R.string.permission_mic),
-                                permissionDescription = stringResource(R.string.permission_mic_desc)
-                            ),
-                            PermissionData(
-                                imageVector = Icons.Default.MyLocation,
-                                isOptional = true,
-                                contentDescription = stringResource(R.string.permission_location_content_desc),
-                                permissionTitle = stringResource(R.string.permission_location),
-                                permissionDescription = stringResource(R.string.permission_location_desc),
-                            )
-                        )
+                        permissions = ALL_PERMISSIONS
                     )
                 }
             }
@@ -182,29 +165,36 @@ fun PermissionScreen(
 
 @Composable
 private fun PermissionMenus(
-    items: List<PermissionData>,
+    permissions: List<String>,
     modifier: Modifier = Modifier
 ) {
+    val context = LocalContext.current
     val essentialString = stringResource(R.string.essential)
     val optionalString = stringResource(R.string.optional)
+
+    val items = permissions.map { permission ->
+        PermissionDataFactory.from(permission, context)
+    }
 
     Column(
         modifier = modifier,
         verticalArrangement = Arrangement.spacedBy(30.dp)
     ) {
         for (item in items) {
-            PermissionItem(
-                imageVector = item.imageVector,
-                contentDescription = item.contentDescription,
-                permissionTitle = item.permissionTitle + " " + if (item.isOptional) optionalString else essentialString,
-                permissionDescription = item.permissionDescription
-            )
+            item?.run {
+                PermissionMenuItem(
+                    imageVector = imageVector,
+                    contentDescription = contentDescription,
+                    permissionTitle = permissionTitle + " " + if (isOptional) optionalString else essentialString,
+                    permissionDescription = permissionDescription
+                )
+            }
         }
     }
 }
 
 @Composable
-private fun PermissionItem(
+private fun PermissionMenuItem(
     imageVector: ImageVector,
     contentDescription: String,
     permissionTitle: String,


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호

## 📝작업 내용 및 코드

## 1. 위치권한 선택 변경

위치권한을 필수에서 선택으로 변경하였습니다.

- 최초실행, 위치권한 비허용
네이버맵 자체에 설정된 디폴트 위치 ( 서울시청) 으로
- 앱 사용 중 위치권한 비허용
로컬기기의 DataStore에 기록된 마지막 위치로 카메라 이동, 픽 등록 비활성화

## 2. 코드 정리

~~MapScreen과 NaverMap 에서 파라미터로 뷰모델을 받아쓰는게 있어서 수정했습니다.
이 과정에서 상태나 람다 파라미터들이 너무 많아져서 데이터 클래스로 묶는 등 코드 정리가 있었습니다.~~

-> (7/15) 인포윈도우 버그가 있어서 다시 롤백했습니다. 리컴포지션도 더 자주 발생해서 이건 더 공부하고 나~~중에 다시 정리해보겠습니다

또한 위치를 나타내는 변수들에 네이버맵sdk에서 제공하는 `LatLng` 클래스, 안드로이드 자체의 `Location` 클래스 두개가 혼용되고 있어서`LocationPoint` 데이터 클래스로 통일했습니다.
이를 이용해서 기존 `Location` 클래스 사용으로 인해 안드로이드 의존성을 가지고 있던 `domain:location` 모듈을 순수 자바/코틀린 모듈로 변경했습니다.

feature:permission 모듈에도 자잘한 변경이 있습니다.
`PermissionMenu`에 `PermissionData` 하나씩 만들어서 넣는걸 더 효율적으로 바꾸었습니다.

## 💬리뷰 요구사항(선택)
